### PR TITLE
Add Show typeclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ Carthage/
 # https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
 #
 Pods/
+
+Bow\.xcodeproj/project\.xcworkspace/xcshareddata/IDEWorkspaceChecks\.plist

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		111082CC2085D9DD00C8563C /* Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082CB2085D9DD00C8563C /* Show.swift */; };
+		111082CD2085DBF700C8563C /* Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082CB2085D9DD00C8563C /* Show.swift */; };
+		111082CE2085DBF800C8563C /* Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082CB2085D9DD00C8563C /* Show.swift */; };
+		111082CF2085DBF800C8563C /* Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082CB2085D9DD00C8563C /* Show.swift */; };
 		D68A5220206811DF008DA945 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D68A51FE206811C6008DA945 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D68A5221206811DF008DA945 /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D68A5200206811C6008DA945 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D6D624442068141800739E2D /* Function0Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_90 /* Function0Test.swift */; };
@@ -496,6 +500,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		111082CB2085D9DD00C8563C /* Show.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Show.swift; sourceTree = "<group>"; };
 		"Bow::Bow::Product" /* Bow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Bow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Bow::BowTests::Product" /* BowTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = BowTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D68A51FE206811C6008DA945 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = "<group>"; };
@@ -923,6 +928,7 @@
 				OBJ_82 /* Reducible.swift */,
 				OBJ_83 /* Semigroup.swift */,
 				OBJ_84 /* SemigroupK.swift */,
+				111082CB2085D9DD00C8563C /* Show.swift */,
 				OBJ_85 /* Traverse.swift */,
 				OBJ_86 /* TraverseFilter.swift */,
 			);
@@ -1338,6 +1344,7 @@
 				D6D624E92068178800739E2D /* Try.swift in Sources */,
 				D6D624EA2068178800739E2D /* Tuple.swift in Sources */,
 				D6D624EB2068178800739E2D /* Validated.swift in Sources */,
+				111082CD2085DBF700C8563C /* Show.swift in Sources */,
 				D6D624EC2068178800739E2D /* AsyncContext.swift in Sources */,
 				D6D624ED2068178800739E2D /* IO.swift in Sources */,
 				D6D624EE2068178800739E2D /* Cofree.swift in Sources */,
@@ -1467,6 +1474,7 @@
 				D6D6257A206841B300739E2D /* Try.swift in Sources */,
 				D6D6257B206841B300739E2D /* Tuple.swift in Sources */,
 				D6D6257C206841B300739E2D /* Validated.swift in Sources */,
+				111082CE2085DBF800C8563C /* Show.swift in Sources */,
 				D6D6257D206841B300739E2D /* AsyncContext.swift in Sources */,
 				D6D6257E206841B300739E2D /* IO.swift in Sources */,
 				D6D6257F206841B300739E2D /* Cofree.swift in Sources */,
@@ -1544,6 +1552,7 @@
 				D6DBDEB020684C38004F979F /* Try.swift in Sources */,
 				D6DBDEB120684C38004F979F /* Tuple.swift in Sources */,
 				D6DBDEB220684C38004F979F /* Validated.swift in Sources */,
+				111082CF2085DBF800C8563C /* Show.swift in Sources */,
 				D6DBDEB320684C38004F979F /* AsyncContext.swift in Sources */,
 				D6DBDEB420684C38004F979F /* IO.swift in Sources */,
 				D6DBDEB520684C38004F979F /* Cofree.swift in Sources */,
@@ -1673,6 +1682,7 @@
 				OBJ_403 /* Try.swift in Sources */,
 				OBJ_404 /* Tuple.swift in Sources */,
 				OBJ_405 /* Validated.swift in Sources */,
+				111082CC2085D9DD00C8563C /* Show.swift in Sources */,
 				OBJ_406 /* AsyncContext.swift in Sources */,
 				OBJ_407 /* IO.swift in Sources */,
 				OBJ_408 /* Cofree.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -986,15 +986,15 @@
 		OBJ_88 /* BowTests */ = {
 			isa = PBXGroup;
 			children = (
-				OBJ_89 /* Arrow */,
 				OBJ_94 /* BooleanFunctionsTest.swift */,
 				OBJ_95 /* CurryTest.swift */,
+				OBJ_117 /* PartialApplicationTest.swift */,
+				OBJ_118 /* PredefTest.swift */,
+				OBJ_89 /* Arrow */,
 				OBJ_96 /* Data */,
 				OBJ_109 /* Effects */,
 				OBJ_112 /* Free */,
 				OBJ_114 /* Instances */,
-				OBJ_117 /* PartialApplicationTest.swift */,
-				OBJ_118 /* PredefTest.swift */,
 				OBJ_119 /* Transformers */,
 				OBJ_124 /* Typeclasses */,
 			);

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		111082CD2085DBF700C8563C /* Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082CB2085D9DD00C8563C /* Show.swift */; };
 		111082CE2085DBF800C8563C /* Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082CB2085D9DD00C8563C /* Show.swift */; };
 		111082CF2085DBF800C8563C /* Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082CB2085D9DD00C8563C /* Show.swift */; };
+		111082D12085DD4D00C8563C /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		D68A5220206811DF008DA945 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D68A51FE206811C6008DA945 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D68A5221206811DF008DA945 /* SwiftCheck.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = D68A5200206811C6008DA945 /* SwiftCheck.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D6D624442068141800739E2D /* Function0Test.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_90 /* Function0Test.swift */; };
@@ -501,6 +502,7 @@
 
 /* Begin PBXFileReference section */
 		111082CB2085D9DD00C8563C /* Show.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Show.swift; sourceTree = "<group>"; };
+		111082D02085DD4D00C8563C /* ShowLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowLaws.swift; sourceTree = "<group>"; };
 		"Bow::Bow::Product" /* Bow.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Bow.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		"Bow::BowTests::Product" /* BowTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = BowTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D68A51FE206811C6008DA945 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = "<group>"; };
@@ -805,6 +807,7 @@
 				OBJ_138 /* OrderLaws.swift */,
 				OBJ_139 /* SemigroupKLaws.swift */,
 				OBJ_140 /* SemigroupLaws.swift */,
+				111082D02085DD4D00C8563C /* ShowLaws.swift */,
 			);
 			path = Typeclasses;
 			sourceTree = "<group>";
@@ -1642,6 +1645,7 @@
 				OBJ_280 /* FunctorLaws.swift in Sources */,
 				OBJ_281 /* MonadErrorLaws.swift in Sources */,
 				OBJ_282 /* MonadFilterLaws.swift in Sources */,
+				111082D12085DD4D00C8563C /* ShowLaws.swift in Sources */,
 				OBJ_283 /* MonadLaws.swift in Sources */,
 				OBJ_284 /* MonadStateLaws.swift in Sources */,
 				OBJ_285 /* MonadWriterLaws.swift in Sources */,

--- a/Sources/Bow/Typeclasses/Show.swift
+++ b/Sources/Bow/Typeclasses/Show.swift
@@ -1,0 +1,28 @@
+//
+//  Show.swift
+//  Bow
+//
+//  Created by Tomás Ruiz López on 17/4/18.
+//
+
+import Foundation
+
+public protocol Show : Typeclass {
+    associatedtype A
+    
+    func show(_ a : A) -> String
+}
+
+public extension CustomStringConvertible {
+    public static func show() -> ShowCustomStringConvertible<Self> {
+        return ShowCustomStringConvertible<Self>()
+    }
+}
+
+public class ShowCustomStringConvertible<B> : Show where B : CustomStringConvertible{
+    public typealias A = B
+    
+    public func show(_ a : B) -> String {
+        return a.description
+    }
+}

--- a/Tests/BowTests/Data/ConstTest.swift
+++ b/Tests/BowTests/Data/ConstTest.swift
@@ -49,4 +49,8 @@ class ConstTest: XCTestCase {
                 eq: self.eq)
         }
     }
+    
+    func testShowLaws() {
+        ShowLaws.check(show: Const.show(), generator: { a in Const<Int, Int>.pure(a) })
+    }
 }

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -51,6 +51,10 @@ class EitherTest: XCTestCase {
         SemigroupKLaws<EitherPartial<Int>>.check(semigroupK: Either<Int, Int>.semigroupK(), generator: self.generator, eq: self.eq)
     }
     
+    func testShowLaws() {
+        ShowLaws.check(show: Either.show(), generator: { a in (a % 2 == 0) ? Either<Int, Int>.pure(a) : Either<Int, Int>.left(a) })
+    }
+    
     func testCheckers() {
         let left = Either<String, Int>.left("Hello")
         let right = Either<String, Int>.right(5)

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -37,4 +37,8 @@ class IdTest: XCTestCase {
     func testComonadLaws() {
         ComonadLaws<ForId>.check(comonad: Id<Int>.comonad(), generator: self.generator, eq: self.eq)
     }
+    
+    func testShowLaws() {
+        ShowLaws.check(show: Id.show(), generator: { a in Id.pure(a) })
+    }
 }

--- a/Tests/BowTests/Data/IorTest.swift
+++ b/Tests/BowTests/Data/IorTest.swift
@@ -32,4 +32,14 @@ class IorTest: XCTestCase {
     func testMonadLaws() {
         MonadLaws<IorPartial<Int>>.check(monad: Ior<Int, Int>.monad(Int.sumMonoid), eq: self.eq)
     }
+    
+    func testShowLaws() {
+        ShowLaws.check(show: Ior.show(), generator: { (a : Int) -> Ior<Int, Int> in
+            switch a % 3 {
+            case 0 : return Ior.left(a)
+            case 1: return Ior.right(a)
+            default: return Ior.both(a, a)
+            }
+        })
+    }
 }

--- a/Tests/BowTests/Data/MaybeTest.swift
+++ b/Tests/BowTests/Data/MaybeTest.swift
@@ -78,4 +78,8 @@ class MaybeTest: XCTestCase {
     func testMonadFilterLaws() {
         MonadFilterLaws<ForMaybe>.check(monadFilter: Maybe<Int>.monadFilter(), generator: self.generator, eq: self.eq)
     }
+    
+    func testShowLaws() {
+        ShowLaws.check(show: Maybe.show(), generator: { a in (a % 2 == 0) ? Maybe.some(a) : Maybe.none() })
+    }
 }

--- a/Tests/BowTests/Data/NonEmptyListTest.swift
+++ b/Tests/BowTests/Data/NonEmptyListTest.swift
@@ -53,4 +53,8 @@ class NonEmptyListTest: XCTestCase {
     func testSemigroupKLaws() {
         SemigroupKLaws<ForNonEmptyList>.check(semigroupK: NonEmptyList<Int>.semigroupK(), generator: self.generator, eq: self.eq)
     }
+    
+    func testShowLaws() {
+        ShowLaws.check(show: NonEmptyList.show(), generator: { a in NonEmptyList(head: a, tail: [a, a])})
+    }
 }

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -41,4 +41,8 @@ class TryTest: XCTestCase {
     func testMonadErrorLaws() {
         MonadErrorLaws<ForTry, CategoryError>.check(monadError: Try<Int>.monadError(), eq: self.eq, gen: { CategoryError.arbitrary.generate })
     }
+    
+    func testShowLaws() {
+        ShowLaws.check(show: Try.show(), generator: { a in (a % 2 == 0) ? Try.success(a) : Try.failure(TryError.illegalState) })
+    }
 }

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -33,4 +33,8 @@ class ValidatedTest: XCTestCase {
     func testSemigroupKLaws() {
         SemigroupKLaws<ValidatedPartial<Int>>.check(semigroupK: Validated<Int, Int>.semigroupK(Int.sumMonoid), generator: self.generator, eq: self.eq)
     }
+    
+    func testShowLaws() {
+        ShowLaws.check(show: Validated.show(), generator: { a in (a % 2 == 0) ? Validated.valid(a) : Validated.invalid(a) })
+    }
 }

--- a/Tests/BowTests/Typeclasses/ShowLaws.swift
+++ b/Tests/BowTests/Typeclasses/ShowLaws.swift
@@ -1,0 +1,26 @@
+//
+//  ShowLaws.swift
+//  BowTests
+//
+//  Created by Tomás Ruiz López on 17/4/18.
+//
+
+import XCTest
+import SwiftCheck
+@testable import Bow
+
+class ShowLaws {
+    
+    static func check<Sh, A>(show : Sh, generator : @escaping (Int) -> A) where Sh : Show, Sh.A == A {
+        equality(show, generator)
+    }
+    
+    private static func equality<Sh, A>(_ show : Sh, _ generator : @escaping (Int) -> A) where Sh : Show, Sh.A == A {
+        property("Equal objects must show equal content") <- forAll { (a : Int) in
+            let x1 = generator(a)
+            let x2 = generator(a)
+            return show.show(x1) == show.show(x2)
+        }
+    }
+    
+}


### PR DESCRIPTION
The PR adds `Show` typeclass and its test laws. It provides a default instance of `Show` for all those classes that implement `CustomStringConvertible` in Swift. Currently, the following data classes provide such implementation in Bow:
- Const
- Either
- Id
- Ior
- Maybe
- NonEmptyList
- Try
- Validated

All of them have been tested. Additionally, all Swift plain types implement `CustomStringConvertible` and as such provide a `Show` instance.