### PR TITLE
Extend datatypes with optics

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		111082CF2085DBF800C8563C /* Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082CB2085D9DD00C8563C /* Show.swift */; };
 		111082D12085DD4D00C8563C /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		1116204620F37AE300685EC4 /* Either+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204520F37AE300685EC4 /* Either+Optics.swift */; };
+		1116204820F37D1900685EC4 /* Id+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204720F37D1900685EC4 /* Id+Optics.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -603,6 +604,7 @@
 		111082CB2085D9DD00C8563C /* Show.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Show.swift; sourceTree = "<group>"; };
 		111082D02085DD4D00C8563C /* ShowLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowLaws.swift; sourceTree = "<group>"; };
 		1116204520F37AE300685EC4 /* Either+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Either+Optics.swift"; sourceTree = "<group>"; };
+		1116204720F37D1900685EC4 /* Id+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Id+Optics.swift"; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -831,6 +833,7 @@
 			isa = PBXGroup;
 			children = (
 				1116204520F37AE300685EC4 /* Either+Optics.swift */,
+				1116204720F37D1900685EC4 /* Id+Optics.swift */,
 			);
 			path = STD;
 			sourceTree = "<group>";
@@ -1945,6 +1948,7 @@
 				OBJ_382 /* Function0.swift in Sources */,
 				11E531D7209B4EF400A78E8D /* At.swift in Sources */,
 				OBJ_383 /* Function1.swift in Sources */,
+				1116204820F37D1900685EC4 /* Id+Optics.swift in Sources */,
 				OBJ_384 /* FunctionK.swift in Sources */,
 				OBJ_385 /* Kleisli.swift in Sources */,
 				11E531CB209B2FEA00A78E8D /* MaybeInstances.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		1116205C20F385D400685EC4 /* Id+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204720F37D1900685EC4 /* Id+Optics.swift */; };
 		1116205D20F385D400685EC4 /* ListK+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204920F37DFA00685EC4 /* ListK+Optics.swift */; };
 		1116205E20F385D400685EC4 /* NonEmptyList+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */; };
+		1116206020F38A5C00685EC4 /* String+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116205F20F38A5C00685EC4 /* String+Optics.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -626,6 +627,7 @@
 		1116204920F37DFA00685EC4 /* ListK+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListK+Optics.swift"; sourceTree = "<group>"; };
 		1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NonEmptyList+Optics.swift"; sourceTree = "<group>"; };
 		1116204E20F3820500685EC4 /* Maybe+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Maybe+Optics.swift"; sourceTree = "<group>"; };
+		1116205F20F38A5C00685EC4 /* String+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Optics.swift"; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -858,6 +860,7 @@
 				1116204920F37DFA00685EC4 /* ListK+Optics.swift */,
 				1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */,
 				1116204E20F3820500685EC4 /* Maybe+Optics.swift */,
+				1116205F20F38A5C00685EC4 /* String+Optics.swift */,
 			);
 			path = STD;
 			sourceTree = "<group>";
@@ -2065,6 +2068,7 @@
 				OBJ_440 /* MonadState.swift in Sources */,
 				OBJ_441 /* MonadWriter.swift in Sources */,
 				11C9B6AF20DB8A8D00AFD4AA /* Traversal.swift in Sources */,
+				1116206020F38A5C00685EC4 /* String+Optics.swift in Sources */,
 				OBJ_442 /* Monoid.swift in Sources */,
 				OBJ_443 /* MonoidK.swift in Sources */,
 				OBJ_444 /* NonEmptyReducible.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		111082D12085DD4D00C8563C /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		1116204620F37AE300685EC4 /* Either+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204520F37AE300685EC4 /* Either+Optics.swift */; };
 		1116204820F37D1900685EC4 /* Id+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204720F37D1900685EC4 /* Id+Optics.swift */; };
+		1116204A20F37DFA00685EC4 /* ListK+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204920F37DFA00685EC4 /* ListK+Optics.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -605,6 +606,7 @@
 		111082D02085DD4D00C8563C /* ShowLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowLaws.swift; sourceTree = "<group>"; };
 		1116204520F37AE300685EC4 /* Either+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Either+Optics.swift"; sourceTree = "<group>"; };
 		1116204720F37D1900685EC4 /* Id+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Id+Optics.swift"; sourceTree = "<group>"; };
+		1116204920F37DFA00685EC4 /* ListK+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListK+Optics.swift"; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -834,6 +836,7 @@
 			children = (
 				1116204520F37AE300685EC4 /* Either+Optics.swift */,
 				1116204720F37D1900685EC4 /* Id+Optics.swift */,
+				1116204920F37DFA00685EC4 /* ListK+Optics.swift */,
 			);
 			path = STD;
 			sourceTree = "<group>";
@@ -2015,6 +2018,7 @@
 				OBJ_433 /* FunctorFilter.swift in Sources */,
 				OBJ_434 /* Inject.swift in Sources */,
 				OBJ_435 /* Monad.swift in Sources */,
+				1116204A20F37DFA00685EC4 /* ListK+Optics.swift in Sources */,
 				OBJ_436 /* MonadCombine.swift in Sources */,
 				OBJ_437 /* MonadError.swift in Sources */,
 				OBJ_438 /* MonadFilter.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -37,6 +37,13 @@
 		1116206320F398D800685EC4 /* Try+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116206120F398CB00685EC4 /* Try+Optics.swift */; };
 		1116206420F398D900685EC4 /* Try+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116206120F398CB00685EC4 /* Try+Optics.swift */; };
 		1116206520F398D900685EC4 /* Try+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116206120F398CB00685EC4 /* Try+Optics.swift */; };
+		1116206720F39E0700685EC4 /* Validated+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116206620F39E0700685EC4 /* Validated+Optics.swift */; };
+		1116206820F39EBB00685EC4 /* Validated+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116206620F39E0700685EC4 /* Validated+Optics.swift */; };
+		1116206920F39EBC00685EC4 /* Validated+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116206620F39E0700685EC4 /* Validated+Optics.swift */; };
+		1116206A20F39EBC00685EC4 /* Validated+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116206620F39E0700685EC4 /* Validated+Optics.swift */; };
+		1116206B20F39EC000685EC4 /* String+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116205F20F38A5C00685EC4 /* String+Optics.swift */; };
+		1116206C20F39EC100685EC4 /* String+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116205F20F38A5C00685EC4 /* String+Optics.swift */; };
+		1116206D20F39EC100685EC4 /* String+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116205F20F38A5C00685EC4 /* String+Optics.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -633,6 +640,7 @@
 		1116204E20F3820500685EC4 /* Maybe+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Maybe+Optics.swift"; sourceTree = "<group>"; };
 		1116205F20F38A5C00685EC4 /* String+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Optics.swift"; sourceTree = "<group>"; };
 		1116206120F398CB00685EC4 /* Try+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Try+Optics.swift"; sourceTree = "<group>"; };
+		1116206620F39E0700685EC4 /* Validated+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Validated+Optics.swift"; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -867,6 +875,7 @@
 				1116204E20F3820500685EC4 /* Maybe+Optics.swift */,
 				1116205F20F38A5C00685EC4 /* String+Optics.swift */,
 				1116206120F398CB00685EC4 /* Try+Optics.swift */,
+				1116206620F39E0700685EC4 /* Validated+Optics.swift */,
 			);
 			path = STD;
 			sourceTree = "<group>";
@@ -1569,6 +1578,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				1116206820F39EBB00685EC4 /* Validated+Optics.swift in Sources */,
 				D6D624D32068178800739E2D /* Cokleisli.swift in Sources */,
 				D6D624D42068178800739E2D /* Function0.swift in Sources */,
 				11C9B6D420DCF54A00AFD4AA /* FilterIndex.swift in Sources */,
@@ -1610,6 +1620,7 @@
 				D6D624F12068178800739E2D /* Yoneda.swift in Sources */,
 				D6D624F22068178800739E2D /* HigherKinds.swift in Sources */,
 				D6D624F32068178800739E2D /* NumberInstances.swift in Sources */,
+				1116206B20F39EC000685EC4 /* String+Optics.swift in Sources */,
 				D6D624F42068178800739E2D /* StringInstances.swift in Sources */,
 				11E531DB209B4FD200A78E8D /* BoundSetter.swift in Sources */,
 				D6D624F52068178800739E2D /* PartialApplication.swift in Sources */,
@@ -1733,6 +1744,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				1116206920F39EBC00685EC4 /* Validated+Optics.swift in Sources */,
 				D6D62564206841B300739E2D /* Cokleisli.swift in Sources */,
 				D6D62565206841B300739E2D /* Function0.swift in Sources */,
 				11C9B6D520DCF54B00AFD4AA /* FilterIndex.swift in Sources */,
@@ -1774,6 +1786,7 @@
 				D6D62582206841B300739E2D /* Yoneda.swift in Sources */,
 				D6D62583206841B300739E2D /* HigherKinds.swift in Sources */,
 				D6D62584206841B300739E2D /* NumberInstances.swift in Sources */,
+				1116206C20F39EC100685EC4 /* String+Optics.swift in Sources */,
 				D6D62585206841B300739E2D /* StringInstances.swift in Sources */,
 				11E531DC209B4FD300A78E8D /* BoundSetter.swift in Sources */,
 				D6D62586206841B300739E2D /* PartialApplication.swift in Sources */,
@@ -1831,6 +1844,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1116206A20F39EBC00685EC4 /* Validated+Optics.swift in Sources */,
 				D6DBDE9A20684C38004F979F /* Cokleisli.swift in Sources */,
 				D6DBDE9B20684C38004F979F /* Function0.swift in Sources */,
 				11C9B6D620DCF54B00AFD4AA /* FilterIndex.swift in Sources */,
@@ -1872,6 +1886,7 @@
 				D6DBDEB820684C38004F979F /* Yoneda.swift in Sources */,
 				D6DBDEB920684C38004F979F /* HigherKinds.swift in Sources */,
 				D6DBDEBA20684C38004F979F /* NumberInstances.swift in Sources */,
+				1116206D20F39EC100685EC4 /* String+Optics.swift in Sources */,
 				D6DBDEBB20684C38004F979F /* StringInstances.swift in Sources */,
 				11E531DD209B4FD400A78E8D /* BoundSetter.swift in Sources */,
 				D6DBDEBC20684C38004F979F /* PartialApplication.swift in Sources */,
@@ -2059,6 +2074,7 @@
 				OBJ_428 /* Composed.swift in Sources */,
 				11E531C5209B29EF00A78E8D /* BoolInstances.swift in Sources */,
 				OBJ_429 /* ComposedFoldable.swift in Sources */,
+				1116206720F39E0700685EC4 /* Validated+Optics.swift in Sources */,
 				OBJ_430 /* Eq.swift in Sources */,
 				11E531B6209AF80100A78E8D /* Optional.swift in Sources */,
 				OBJ_431 /* Foldable.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		111082CE2085DBF800C8563C /* Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082CB2085D9DD00C8563C /* Show.swift */; };
 		111082CF2085DBF800C8563C /* Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082CB2085D9DD00C8563C /* Show.swift */; };
 		111082D12085DD4D00C8563C /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
+		1116204620F37AE300685EC4 /* Either+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204520F37AE300685EC4 /* Either+Optics.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -601,6 +602,7 @@
 /* Begin PBXFileReference section */
 		111082CB2085D9DD00C8563C /* Show.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Show.swift; sourceTree = "<group>"; };
 		111082D02085DD4D00C8563C /* ShowLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowLaws.swift; sourceTree = "<group>"; };
+		1116204520F37AE300685EC4 /* Either+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Either+Optics.swift"; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -825,6 +827,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1116204420F37ABA00685EC4 /* STD */ = {
+			isa = PBXGroup;
+			children = (
+				1116204520F37AE300685EC4 /* Either+Optics.swift */,
+			);
+			path = STD;
+			sourceTree = "<group>";
+		};
 		11AC527120974B29008EC1E4 /* Optics */ = {
 			isa = PBXGroup;
 			children = (
@@ -837,6 +847,7 @@
 				11E531B0209AE89A00A78E8D /* Prism.swift */,
 				11E531BA209B0BE300A78E8D /* Setter.swift */,
 				11C9B6AE20DB8A8D00AFD4AA /* Traversal.swift */,
+				1116204420F37ABA00685EC4 /* STD */,
 				11E531D5209B4ECC00A78E8D /* Typeclasses */,
 			);
 			path = Optics;
@@ -1988,6 +1999,7 @@
 				OBJ_425 /* Bifoldable.swift in Sources */,
 				OBJ_426 /* Bimonad.swift in Sources */,
 				OBJ_427 /* Comonad.swift in Sources */,
+				1116204620F37AE300685EC4 /* Either+Optics.swift in Sources */,
 				OBJ_428 /* Composed.swift in Sources */,
 				11E531C5209B29EF00A78E8D /* BoolInstances.swift in Sources */,
 				OBJ_429 /* ComposedFoldable.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		1116205D20F385D400685EC4 /* ListK+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204920F37DFA00685EC4 /* ListK+Optics.swift */; };
 		1116205E20F385D400685EC4 /* NonEmptyList+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */; };
 		1116206020F38A5C00685EC4 /* String+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116205F20F38A5C00685EC4 /* String+Optics.swift */; };
+		1116206220F398CB00685EC4 /* Try+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116206120F398CB00685EC4 /* Try+Optics.swift */; };
+		1116206320F398D800685EC4 /* Try+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116206120F398CB00685EC4 /* Try+Optics.swift */; };
+		1116206420F398D900685EC4 /* Try+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116206120F398CB00685EC4 /* Try+Optics.swift */; };
+		1116206520F398D900685EC4 /* Try+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116206120F398CB00685EC4 /* Try+Optics.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -628,6 +632,7 @@
 		1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NonEmptyList+Optics.swift"; sourceTree = "<group>"; };
 		1116204E20F3820500685EC4 /* Maybe+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Maybe+Optics.swift"; sourceTree = "<group>"; };
 		1116205F20F38A5C00685EC4 /* String+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Optics.swift"; sourceTree = "<group>"; };
+		1116206120F398CB00685EC4 /* Try+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Try+Optics.swift"; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -861,6 +866,7 @@
 				1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */,
 				1116204E20F3820500685EC4 /* Maybe+Optics.swift */,
 				1116205F20F38A5C00685EC4 /* String+Optics.swift */,
+				1116206120F398CB00685EC4 /* Try+Optics.swift */,
 			);
 			path = STD;
 			sourceTree = "<group>";
@@ -1599,6 +1605,7 @@
 				D6D624EE2068178800739E2D /* Cofree.swift in Sources */,
 				D6D624EF2068178800739E2D /* Coyoneda.swift in Sources */,
 				11E531C1209B1CE700A78E8D /* Fold.swift in Sources */,
+				1116206320F398D800685EC4 /* Try+Optics.swift in Sources */,
 				D6D624F02068178800739E2D /* Free.swift in Sources */,
 				D6D624F12068178800739E2D /* Yoneda.swift in Sources */,
 				D6D624F22068178800739E2D /* HigherKinds.swift in Sources */,
@@ -1762,6 +1769,7 @@
 				D6D6257F206841B300739E2D /* Cofree.swift in Sources */,
 				D6D62580206841B300739E2D /* Coyoneda.swift in Sources */,
 				11E531C2209B1CE800A78E8D /* Fold.swift in Sources */,
+				1116206420F398D900685EC4 /* Try+Optics.swift in Sources */,
 				D6D62581206841B300739E2D /* Free.swift in Sources */,
 				D6D62582206841B300739E2D /* Yoneda.swift in Sources */,
 				D6D62583206841B300739E2D /* HigherKinds.swift in Sources */,
@@ -1859,6 +1867,7 @@
 				D6DBDEB520684C38004F979F /* Cofree.swift in Sources */,
 				D6DBDEB620684C38004F979F /* Coyoneda.swift in Sources */,
 				11E531C3209B1CE900A78E8D /* Fold.swift in Sources */,
+				1116206520F398D900685EC4 /* Try+Optics.swift in Sources */,
 				D6DBDEB720684C38004F979F /* Free.swift in Sources */,
 				D6DBDEB820684C38004F979F /* Yoneda.swift in Sources */,
 				D6DBDEB920684C38004F979F /* HigherKinds.swift in Sources */,
@@ -2077,6 +2086,7 @@
 				OBJ_447 /* Semigroup.swift in Sources */,
 				OBJ_448 /* SemigroupK.swift in Sources */,
 				OBJ_449 /* Traverse.swift in Sources */,
+				1116206220F398CB00685EC4 /* Try+Optics.swift in Sources */,
 				OBJ_450 /* TraverseFilter.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -16,6 +16,22 @@
 		1116204820F37D1900685EC4 /* Id+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204720F37D1900685EC4 /* Id+Optics.swift */; };
 		1116204A20F37DFA00685EC4 /* ListK+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204920F37DFA00685EC4 /* ListK+Optics.swift */; };
 		1116204C20F380E300685EC4 /* NonEmptyList+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */; };
+		1116204F20F3820500685EC4 /* Maybe+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204E20F3820500685EC4 /* Maybe+Optics.swift */; };
+		1116205020F385C300685EC4 /* Maybe+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204E20F3820500685EC4 /* Maybe+Optics.swift */; };
+		1116205120F385C400685EC4 /* Maybe+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204E20F3820500685EC4 /* Maybe+Optics.swift */; };
+		1116205220F385C500685EC4 /* Maybe+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204E20F3820500685EC4 /* Maybe+Optics.swift */; };
+		1116205320F385D300685EC4 /* Either+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204520F37AE300685EC4 /* Either+Optics.swift */; };
+		1116205420F385D300685EC4 /* Id+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204720F37D1900685EC4 /* Id+Optics.swift */; };
+		1116205520F385D300685EC4 /* ListK+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204920F37DFA00685EC4 /* ListK+Optics.swift */; };
+		1116205620F385D300685EC4 /* NonEmptyList+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */; };
+		1116205720F385D300685EC4 /* Either+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204520F37AE300685EC4 /* Either+Optics.swift */; };
+		1116205820F385D300685EC4 /* Id+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204720F37D1900685EC4 /* Id+Optics.swift */; };
+		1116205920F385D300685EC4 /* ListK+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204920F37DFA00685EC4 /* ListK+Optics.swift */; };
+		1116205A20F385D300685EC4 /* NonEmptyList+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */; };
+		1116205B20F385D400685EC4 /* Either+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204520F37AE300685EC4 /* Either+Optics.swift */; };
+		1116205C20F385D400685EC4 /* Id+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204720F37D1900685EC4 /* Id+Optics.swift */; };
+		1116205D20F385D400685EC4 /* ListK+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204920F37DFA00685EC4 /* ListK+Optics.swift */; };
+		1116205E20F385D400685EC4 /* NonEmptyList+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -609,6 +625,7 @@
 		1116204720F37D1900685EC4 /* Id+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Id+Optics.swift"; sourceTree = "<group>"; };
 		1116204920F37DFA00685EC4 /* ListK+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListK+Optics.swift"; sourceTree = "<group>"; };
 		1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NonEmptyList+Optics.swift"; sourceTree = "<group>"; };
+		1116204E20F3820500685EC4 /* Maybe+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Maybe+Optics.swift"; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -840,6 +857,7 @@
 				1116204720F37D1900685EC4 /* Id+Optics.swift */,
 				1116204920F37DFA00685EC4 /* ListK+Optics.swift */,
 				1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */,
+				1116204E20F3820500685EC4 /* Maybe+Optics.swift */,
 			);
 			path = STD;
 			sourceTree = "<group>";
@@ -1546,6 +1564,7 @@
 				D6D624D42068178800739E2D /* Function0.swift in Sources */,
 				11C9B6D420DCF54A00AFD4AA /* FilterIndex.swift in Sources */,
 				D6D624D52068178800739E2D /* Function1.swift in Sources */,
+				1116205420F385D300685EC4 /* Id+Optics.swift in Sources */,
 				D6D624D62068178800739E2D /* FunctionK.swift in Sources */,
 				D6D624D72068178800739E2D /* Kleisli.swift in Sources */,
 				D6D624D82068178800739E2D /* KleisliOperator.swift in Sources */,
@@ -1588,6 +1607,7 @@
 				11E531B2209AF13600A78E8D /* Prism.swift in Sources */,
 				D6D624F62068178800739E2D /* Predef.swift in Sources */,
 				D6D624F72068178800739E2D /* EitherT.swift in Sources */,
+				1116205620F385D300685EC4 /* NonEmptyList+Optics.swift in Sources */,
 				D6D624F82068178800739E2D /* MaybeT.swift in Sources */,
 				D6D624F92068178800739E2D /* StateT.swift in Sources */,
 				D6D624FA2068178800739E2D /* WriterT.swift in Sources */,
@@ -1600,6 +1620,7 @@
 				D6D624FF2068178800739E2D /* Bifoldable.swift in Sources */,
 				D6D625002068178800739E2D /* Bimonad.swift in Sources */,
 				D6D625012068178800739E2D /* Comonad.swift in Sources */,
+				1116205320F385D300685EC4 /* Either+Optics.swift in Sources */,
 				D6D625022068178800739E2D /* Composed.swift in Sources */,
 				D6D625032068178800739E2D /* ComposedFoldable.swift in Sources */,
 				D6D625042068178800739E2D /* Eq.swift in Sources */,
@@ -1611,6 +1632,7 @@
 				D6D625082068178800739E2D /* Inject.swift in Sources */,
 				D6D625092068178800739E2D /* Monad.swift in Sources */,
 				D6D6250A2068178800739E2D /* MonadCombine.swift in Sources */,
+				1116205520F385D300685EC4 /* ListK+Optics.swift in Sources */,
 				D6D6250B2068178800739E2D /* MonadError.swift in Sources */,
 				D6D6250C2068178800739E2D /* MonadFilter.swift in Sources */,
 				11E531BC209B148E00A78E8D /* Setter.swift in Sources */,
@@ -1624,6 +1646,7 @@
 				11E531E0209B502F00A78E8D /* Index.swift in Sources */,
 				D6D625142068178800739E2D /* Reducible.swift in Sources */,
 				D6D625152068178800739E2D /* Semigroup.swift in Sources */,
+				1116205020F385C300685EC4 /* Maybe+Optics.swift in Sources */,
 				D6D625162068178800739E2D /* SemigroupK.swift in Sources */,
 				D6D625172068178800739E2D /* Traverse.swift in Sources */,
 				D6D625182068178800739E2D /* TraverseFilter.swift in Sources */,
@@ -1704,6 +1727,7 @@
 				D6D62565206841B300739E2D /* Function0.swift in Sources */,
 				11C9B6D520DCF54B00AFD4AA /* FilterIndex.swift in Sources */,
 				D6D62566206841B300739E2D /* Function1.swift in Sources */,
+				1116205820F385D300685EC4 /* Id+Optics.swift in Sources */,
 				D6D62567206841B300739E2D /* FunctionK.swift in Sources */,
 				D6D62568206841B300739E2D /* Kleisli.swift in Sources */,
 				D6D62569206841B300739E2D /* KleisliOperator.swift in Sources */,
@@ -1746,6 +1770,7 @@
 				11E531B3209AF13600A78E8D /* Prism.swift in Sources */,
 				D6D62587206841B300739E2D /* Predef.swift in Sources */,
 				D6D62588206841B300739E2D /* EitherT.swift in Sources */,
+				1116205A20F385D300685EC4 /* NonEmptyList+Optics.swift in Sources */,
 				D6D62589206841B300739E2D /* MaybeT.swift in Sources */,
 				D6D6258A206841B300739E2D /* StateT.swift in Sources */,
 				D6D6258B206841B300739E2D /* WriterT.swift in Sources */,
@@ -1758,6 +1783,7 @@
 				D6D62590206841B300739E2D /* Bifoldable.swift in Sources */,
 				D6D62591206841B300739E2D /* Bimonad.swift in Sources */,
 				D6D62592206841B300739E2D /* Comonad.swift in Sources */,
+				1116205720F385D300685EC4 /* Either+Optics.swift in Sources */,
 				D6D62593206841B300739E2D /* Composed.swift in Sources */,
 				D6D62594206841B300739E2D /* ComposedFoldable.swift in Sources */,
 				D6D62595206841B300739E2D /* Eq.swift in Sources */,
@@ -1769,6 +1795,7 @@
 				D6D62599206841B300739E2D /* Inject.swift in Sources */,
 				D6D6259A206841B300739E2D /* Monad.swift in Sources */,
 				D6D6259B206841B300739E2D /* MonadCombine.swift in Sources */,
+				1116205920F385D300685EC4 /* ListK+Optics.swift in Sources */,
 				D6D6259C206841B300739E2D /* MonadError.swift in Sources */,
 				D6D6259D206841B300739E2D /* MonadFilter.swift in Sources */,
 				11E531BD209B148E00A78E8D /* Setter.swift in Sources */,
@@ -1782,6 +1809,7 @@
 				11E531E1209B503000A78E8D /* Index.swift in Sources */,
 				D6D625A5206841B300739E2D /* Reducible.swift in Sources */,
 				D6D625A6206841B300739E2D /* Semigroup.swift in Sources */,
+				1116205120F385C400685EC4 /* Maybe+Optics.swift in Sources */,
 				D6D625A7206841B300739E2D /* SemigroupK.swift in Sources */,
 				D6D625A8206841B300739E2D /* Traverse.swift in Sources */,
 				D6D625A9206841B300739E2D /* TraverseFilter.swift in Sources */,
@@ -1796,6 +1824,7 @@
 				D6DBDE9B20684C38004F979F /* Function0.swift in Sources */,
 				11C9B6D620DCF54B00AFD4AA /* FilterIndex.swift in Sources */,
 				D6DBDE9C20684C38004F979F /* Function1.swift in Sources */,
+				1116205C20F385D400685EC4 /* Id+Optics.swift in Sources */,
 				D6DBDE9D20684C38004F979F /* FunctionK.swift in Sources */,
 				D6DBDE9E20684C38004F979F /* Kleisli.swift in Sources */,
 				D6DBDE9F20684C38004F979F /* KleisliOperator.swift in Sources */,
@@ -1838,6 +1867,7 @@
 				11E531B4209AF13700A78E8D /* Prism.swift in Sources */,
 				D6DBDEBD20684C38004F979F /* Predef.swift in Sources */,
 				D6DBDEBE20684C38004F979F /* EitherT.swift in Sources */,
+				1116205E20F385D400685EC4 /* NonEmptyList+Optics.swift in Sources */,
 				D6DBDEBF20684C38004F979F /* MaybeT.swift in Sources */,
 				D6DBDEC020684C38004F979F /* StateT.swift in Sources */,
 				D6DBDEC120684C38004F979F /* WriterT.swift in Sources */,
@@ -1850,6 +1880,7 @@
 				D6DBDEC620684C38004F979F /* Bifoldable.swift in Sources */,
 				D6DBDEC720684C38004F979F /* Bimonad.swift in Sources */,
 				D6DBDEC820684C38004F979F /* Comonad.swift in Sources */,
+				1116205B20F385D400685EC4 /* Either+Optics.swift in Sources */,
 				D6DBDEC920684C38004F979F /* Composed.swift in Sources */,
 				D6DBDECA20684C38004F979F /* ComposedFoldable.swift in Sources */,
 				D6DBDECB20684C38004F979F /* Eq.swift in Sources */,
@@ -1861,6 +1892,7 @@
 				D6DBDECF20684C38004F979F /* Inject.swift in Sources */,
 				D6DBDED020684C38004F979F /* Monad.swift in Sources */,
 				D6DBDED120684C38004F979F /* MonadCombine.swift in Sources */,
+				1116205D20F385D400685EC4 /* ListK+Optics.swift in Sources */,
 				D6DBDED220684C38004F979F /* MonadError.swift in Sources */,
 				D6DBDED320684C38004F979F /* MonadFilter.swift in Sources */,
 				11E531BE209B148F00A78E8D /* Setter.swift in Sources */,
@@ -1874,6 +1906,7 @@
 				11E531E2209B503000A78E8D /* Index.swift in Sources */,
 				D6DBDEDB20684C38004F979F /* Reducible.swift in Sources */,
 				D6DBDEDC20684C38004F979F /* Semigroup.swift in Sources */,
+				1116205220F385C500685EC4 /* Maybe+Optics.swift in Sources */,
 				D6DBDEDD20684C38004F979F /* SemigroupK.swift in Sources */,
 				D6DBDEDE20684C38004F979F /* Traverse.swift in Sources */,
 				D6DBDEDF20684C38004F979F /* TraverseFilter.swift in Sources */,
@@ -2019,6 +2052,7 @@
 				OBJ_431 /* Foldable.swift in Sources */,
 				OBJ_432 /* Functor.swift in Sources */,
 				11E531DF209B502900A78E8D /* Index.swift in Sources */,
+				1116204F20F3820500685EC4 /* Maybe+Optics.swift in Sources */,
 				OBJ_433 /* FunctorFilter.swift in Sources */,
 				OBJ_434 /* Inject.swift in Sources */,
 				OBJ_435 /* Monad.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		1116204620F37AE300685EC4 /* Either+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204520F37AE300685EC4 /* Either+Optics.swift */; };
 		1116204820F37D1900685EC4 /* Id+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204720F37D1900685EC4 /* Id+Optics.swift */; };
 		1116204A20F37DFA00685EC4 /* ListK+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204920F37DFA00685EC4 /* ListK+Optics.swift */; };
+		1116204C20F380E300685EC4 /* NonEmptyList+Optics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -607,6 +608,7 @@
 		1116204520F37AE300685EC4 /* Either+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Either+Optics.swift"; sourceTree = "<group>"; };
 		1116204720F37D1900685EC4 /* Id+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Id+Optics.swift"; sourceTree = "<group>"; };
 		1116204920F37DFA00685EC4 /* ListK+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ListK+Optics.swift"; sourceTree = "<group>"; };
+		1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NonEmptyList+Optics.swift"; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -837,6 +839,7 @@
 				1116204520F37AE300685EC4 /* Either+Optics.swift */,
 				1116204720F37D1900685EC4 /* Id+Optics.swift */,
 				1116204920F37DFA00685EC4 /* ListK+Optics.swift */,
+				1116204B20F380E300685EC4 /* NonEmptyList+Optics.swift */,
 			);
 			path = STD;
 			sourceTree = "<group>";
@@ -1994,6 +1997,7 @@
 				11AC527520975422008EC1E4 /* Iso.swift in Sources */,
 				11C9B6B320DBB0EC00AFD4AA /* FilterIndex.swift in Sources */,
 				11E531B1209AE89A00A78E8D /* Prism.swift in Sources */,
+				1116204C20F380E300685EC4 /* NonEmptyList+Optics.swift in Sources */,
 				OBJ_416 /* Predef.swift in Sources */,
 				OBJ_417 /* EitherT.swift in Sources */,
 				OBJ_418 /* MaybeT.swift in Sources */,

--- a/Sources/Bow/Data/NonEmptyList.swift
+++ b/Sources/Bow/Data/NonEmptyList.swift
@@ -5,8 +5,8 @@ public typealias NonEmptyListOf<A> = Kind<ForNonEmptyList, A>
 public typealias Nel<A> = NonEmptyList<A>
 
 public class NonEmptyList<A> : NonEmptyListOf<A> {
-    private let head : A
-    private let tail : [A]
+    let head : A
+    let tail : [A]
     
     public static func +(lhs : NonEmptyList<A>, rhs : NonEmptyList<A>) -> NonEmptyList<A> {
         return NonEmptyList(head: lhs.head, tail: lhs.tail + [rhs.head] + rhs.tail)

--- a/Sources/Bow/Optics/STD/Either+Optics.swift
+++ b/Sources/Bow/Optics/STD/Either+Optics.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public extension Either {
+    public static func toPValidated<C, D>() -> PIso<Either<A, B>, Either<C, D>, Validated<A, B>, Validated<C, D>> {
+        return PIso<Either<A, B>, Either<C, D>, Validated<A, B>, Validated<C, D>>(
+            get: { either in either.fold(Validated<A, B>.invalid, Validated<A, B>.valid) },
+            reverseGet: { x in x.toEither() })
+    }
+    
+    public static func toValidated() -> Iso<Either<A, B>, Validated<A, B>> {
+        return toPValidated()
+    }
+}

--- a/Sources/Bow/Optics/STD/Id+Optics.swift
+++ b/Sources/Bow/Optics/STD/Id+Optics.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public extension Id {
+    public static func toPValue<B>() -> PIso<Id<A>, Id<B>, A, B> {
+        return PIso<Id<A>, Id<B>, A, B>(
+            get: { x in x.value },
+            reverseGet: Id<B>.pure)
+    }
+    
+    public static func toValue() -> Iso<Id<A>, A> {
+        return toPValue()
+    }
+}

--- a/Sources/Bow/Optics/STD/ListK+Optics.swift
+++ b/Sources/Bow/Optics/STD/ListK+Optics.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+public extension ListK {
+    public static func toPMaybeNel<B>() -> PIso<ListK<A>, ListK<B>, Maybe<NonEmptyList<A>>, Maybe<NonEmptyList<B>>> {
+        return PIso<ListK<A>, ListK<B>, Maybe<NonEmptyList<A>>, Maybe<NonEmptyList<B>>>(
+            get: { list in list.isEmpty ?
+                Maybe<NonEmptyList<A>>.none() :
+                Maybe<NonEmptyList<A>>.some(NonEmptyList<A>(head: list.asArray[0], tail: Array(list.asArray.dropFirst()))) },
+            reverseGet: { maybe in
+                maybe.fold(ListK<B>.empty, { nel in ListK<B>(nel.all()) })
+        })
+    }
+    
+    public static func toMaybeNel() -> Iso<ListK<A>, Maybe<NonEmptyList<A>>> {
+        return toPMaybeNel()
+    }
+}
+
+public extension Array {
+    public static func toPListK<B>() -> PIso<Array<Element>, Array<B>, ListK<Element>, ListK<B>> {
+        return PIso<Array<Element>, Array<B>, ListK<Element>, ListK<B>>(
+            get: ListK<Element>.init,
+            reverseGet: { list in list.asArray })
+    }
+    
+    public static func toListK() -> Iso<Array<Element>, ListK<Element>> {
+        return toPListK()
+    }
+}

--- a/Sources/Bow/Optics/STD/Maybe+Optics.swift
+++ b/Sources/Bow/Optics/STD/Maybe+Optics.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+public extension Maybe {
+    public static func toPOption<B>() -> PIso<Maybe<A>, Maybe<B>, A?, B?> {
+        return PIso<Maybe<A>, Maybe<B>, A?, B?>(
+            get: { x in x.toOption() },
+            reverseGet: Maybe<B>.fromOption)
+    }
+    
+    public static func toOption() -> Iso<Maybe<A>, A?> {
+        return toPOption()
+    }
+    
+    public static func PSomePrism<B>() -> PPrism<Maybe<A>, Maybe<B>, A, B> {
+        return PPrism<Maybe<A>, Maybe<B>, A, B>(
+            getOrModify: { maybe in
+                maybe.fold({ Either<Maybe<B>, A>.left(Maybe<B>.none()) },
+                           { a in Either<Maybe<B>, A>.right(a) })
+        },
+            reverseGet: Maybe<B>.some)
+    }
+    
+    public static func somePrism() -> Prism<Maybe<A>, A> {
+        return PSomePrism()
+    }
+    
+    public static func nonePrism() -> Prism<Maybe<A>, Unit> {
+        return Prism<Maybe<A>, Unit>(
+            getOrModify: { maybe in
+                maybe.fold({ Either<Maybe<A>, Unit>.right(unit) },
+                           { a in Either<Maybe<A>, Unit>.left(Maybe<A>.some(a)) })
+        },
+            reverseGet: { Maybe<A>.none() })
+    }
+    
+    public static func toPEither<B>() -> PIso<Maybe<A>, Maybe<B>, Either<Unit, A>, Either<Unit, B>> {
+        return PIso<Maybe<A>, Maybe<B>, Either<Unit, A>, Either<Unit, B>>(
+            get: { maybe in maybe.fold({ Either.left(unit) },
+                                       { a in Either.right(a) })
+        },  reverseGet: { either in either.fold({ Maybe<B>.none() },
+                                                { b in Maybe<B>.some(b) })})
+    }
+    
+    public static func toEither() -> Iso<Maybe<A>, Either<Unit, A>> {
+        return toPEither()
+    }
+}

--- a/Sources/Bow/Optics/STD/NonEmptyList+Optics.swift
+++ b/Sources/Bow/Optics/STD/NonEmptyList+Optics.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public extension NonEmptyList {
+    public static func head() -> Lens<NonEmptyList<A>, A> {
+        return Lens<NonEmptyList<A>, A>(
+            get: { x in x.head },
+            set: { (nel, newHead) in NonEmptyList(head: newHead, tail: nel.tail) })
+    }
+    
+    public static func tail() -> Lens<NonEmptyList<A>, [A]> {
+        return Lens<NonEmptyList<A>, [A]>(
+            get: { x in x.tail },
+            set: { (nel, newTail) in NonEmptyList(head: nel.head, tail: newTail) })
+    }
+}

--- a/Sources/Bow/Optics/STD/String+Optics.swift
+++ b/Sources/Bow/Optics/STD/String+Optics.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public extension String {
+    public static func toArray() -> Iso<String, [Character]> {
+        return Iso<String, [Character]>(
+            get: { str in str.map(id) },
+            reverseGet: { characters in String(characters) })
+    }
+    
+    public static func toListK() -> Iso<String, ListK<Character>> {
+        return String.toArray() + Array.toListK()
+    }
+}

--- a/Sources/Bow/Optics/STD/Try+Optics.swift
+++ b/Sources/Bow/Optics/STD/Try+Optics.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+public extension Try {
+    public static func pSuccessPrism<B>() -> PPrism<Try<A>, Try<B>, A, B> {
+        return PPrism<Try<A>, Try<B>, A, B>(
+            getOrModify: { aTry in aTry.fold({ e in Either<Try<B>, A>.left(Try<B>.failure(e)) },
+                                             { a in Either<Try<B>, A>.right(a) }) },
+            reverseGet: Try<B>.success)
+    }
+    
+    public static func successPrism() -> Prism<Try<A>, A> {
+        return pSuccessPrism()
+    }
+    
+    public static func failurePrism() -> Prism<Try<A>, Error> {
+        return Prism<Try<A>, Error>(
+            getOrModify: { aTry in aTry.fold({ e in Either.right(e) },
+                                             { a in Either.left(Try.success(a)) }) },
+            reverseGet: Try.failure )
+    }
+    
+    public static func toPEither<B>() -> PIso<Try<A>, Try<B>, Either<Error, A>, Either<Error, B>> {
+        return PIso<Try<A>, Try<B>, Either<Error, A>, Either<Error, B>>(
+            get: { aTry in aTry.fold(Either<Error, A>.left, Either<Error, A>.right) },
+            reverseGet: { either in either.fold(Try<B>.failure, Try<B>.success) })
+    }
+    
+    public static func toEither() -> Iso<Try<A>, Either<Error, A>> {
+        return toPEither()
+    }
+    
+    public static func toPValidated<B>() -> PIso<Try<A>, Try<B>, Validated<Error, A>, Validated<Error, B>> {
+        return PIso<Try<A>, Try<B>, Validated<Error, A>, Validated<Error, B>>(
+            get: { aTry in aTry.fold(Validated<Error, A>.invalid, Validated<Error, A>.valid)},
+            reverseGet: { validated in validated.fold(Try<B>.failure, Try<B>.success) })
+    }
+    
+    public static func toValidated() -> Iso<Try<A>, Validated<Error, A>> {
+        return toPValidated()
+    }
+}

--- a/Sources/Bow/Optics/STD/Validated+Optics.swift
+++ b/Sources/Bow/Optics/STD/Validated+Optics.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public extension Validated {
+    public static func toPEither<E2, B>() -> PIso<Validated<E, A>, Validated<E2, B>, Either<E, A>, Either<E2, B>> {
+        return PIso<Validated<E, A>, Validated<E2, B>, Either<E, A>, Either<E2, B>>(
+            get: { validated in validated.fold(Either<E, A>.left,
+                                               Either<E, A>.right) },
+            reverseGet: { either in either.fold(Validated<E2, B>.invalid,
+                                                Validated<E2, B>.valid) })
+    }
+    
+    public static func toEither() -> Iso<Validated<E, A>, Either<E, A>> {
+        return toPEither()
+    }
+    
+    public static func toPTry<B>() -> PIso<Validated<Error, A>, Validated<Error, B>, Try<A>, Try<B>> {
+        return PIso<Validated<Error, A>, Validated<Error, B>, Try<A>, Try<B>>(
+            get: { validated in validated.fold(Try<A>.failure,
+                                               Try<A>.success) },
+            reverseGet: Validated<Error, B>.fromTry )
+    }
+    
+    public static func toTry() -> Iso<Validated<Error, A>, Try<A>> {
+        return toPTry()
+    }
+}


### PR DESCRIPTION
This PR extends some of the datatypes with optics. Some still are missing since their corresponding datatypes are not implemented. 