### PR TITLE
Extend optics typeclasses

### DIFF
--- a/Sources/Bow/Optics/Typeclasses/At.swift
+++ b/Sources/Bow/Optics/Typeclasses/At.swift
@@ -7,3 +7,32 @@ public protocol At : Typeclass {
     
     func at(_ i : I) -> Lens<S, A>
 }
+
+public extension At {
+    public static func at<AtType>(_ at : AtType, _ i : I) -> Lens<S, A> where AtType : At, AtType.S == S, AtType.I == I, AtType.A == A {
+        return at.at(i)
+    }
+    
+    public static func fromIso<U, AtType>(_ at : AtType, _ iso : Iso<S, U>) -> AtFromIso<S, I, A, U, AtType> where AtType : At, AtType.S == U, AtType.I == I, AtType.A == A {
+        return AtFromIso(at: at, iso: iso)
+    }
+}
+
+public class AtFromIso<M, N, O, P, AtType> : At where AtType : At, AtType.S == P, AtType.I == N, AtType.A == O {
+    public typealias S = M
+    public typealias I = N
+    public typealias A = O
+    
+    private let atInstance : AtType
+    private let iso : Iso<M, P>
+    
+    public init(at : AtType, iso : Iso<M, P>) {
+        self.atInstance = at
+        self.iso = iso
+    }
+    
+    public func at(_ i: N) -> Lens<M, O> {
+        return iso + atInstance.at(i)
+    }
+    
+}

--- a/Sources/Bow/Optics/Typeclasses/Each.swift
+++ b/Sources/Bow/Optics/Typeclasses/Each.swift
@@ -6,3 +6,45 @@ public protocol Each {
     
     func each() -> Traversal<S, A>
 }
+
+public extension Each {
+    public static func fromIso<B, EachIn>(_ each : EachIn, _ iso : Iso<S, A>) -> EachFromIso<S, B, A, EachIn> where EachIn : Each, EachIn.S == A, EachIn.A == B {
+        return EachFromIso<S, B, A, EachIn>(each : each, iso : iso)
+    }
+    
+    public static func from<Trav>(traverse : Trav) -> EachFromTraverse<S, A, Trav> where Trav : Traverse, Trav.F == S {
+        return EachFromTraverse<S, A, Trav>(traverse: traverse)
+    }
+}
+
+public class EachFromIso<M, N, O, EachIn> : Each where EachIn : Each, EachIn.S == O, EachIn.A == N {
+    public typealias S = M
+    public typealias A = N
+    
+    private let eachObject : EachIn
+    private let iso : Iso<S, O>
+    
+    public init(each eachObject : EachIn, iso : Iso<S, O>) {
+        self.eachObject = eachObject
+        self.iso = iso
+    }
+    
+    public func each() -> Traversal<M, N> {
+        return iso + eachObject.each()
+    }
+}
+
+public class EachFromTraverse<M, N, Trav> : Each where Trav : Traverse, Trav.F == M {
+    public typealias S = Kind<M, N>
+    public typealias A = N
+    
+    private let traverse : Trav
+    
+    public init(traverse : Trav) {
+        self.traverse = traverse
+    }
+
+    public func each() -> Traversal<Kind<M, N>, N> {
+        return Traversal<S, A>.from(traverse: traverse)
+    }
+}

--- a/Sources/Bow/Optics/Typeclasses/FilterIndex.swift
+++ b/Sources/Bow/Optics/Typeclasses/FilterIndex.swift
@@ -5,5 +5,77 @@ public protocol FilterIndex {
     associatedtype I
     associatedtype A
     
-    func filter(_ predicate : (I) -> Bool) -> Traversal<S, A>
+    func filter(_ predicate : @escaping (I) -> Bool) -> Traversal<S, A>
+}
+
+public extension FilterIndex {
+    public static func filterIndex<FilterIdx>(_ fi : FilterIdx, _ predicate : @escaping (I) -> Bool) -> Traversal<S, A> where FilterIdx : FilterIndex, FilterIdx.S == S, FilterIdx.I == I, FilterIdx.A == A {
+        return fi.filter(predicate)
+    }
+    
+    public static func fromIso<FilterIdx, B>(_ fi : FilterIdx, _ iso : Iso<S, A>) -> FilterIndexFromIso<S, I, B, A, FilterIdx> where FilterIdx : FilterIndex, FilterIdx.S == A, FilterIdx.I == I, FilterIdx.A == B {
+        return FilterIndexFromIso<S, I, B, A, FilterIdx>(filterIndex: fi, iso: iso)
+    }
+    
+    public static func from<Trav>(traverse : Trav, zipWithIndex : @escaping (Kind<S, A>) -> Kind<S, (A, Int)>) -> FilterIndexFromTraverse<S, A, Trav> where Trav : Traverse, Trav.F == S {
+        return FilterIndexFromTraverse(zipWithIndex: zipWithIndex, traverse: traverse)
+    }
+}
+
+public class FilterIndexFromIso<M, N, O, P, FilterIdx> : FilterIndex where FilterIdx : FilterIndex, FilterIdx.S == P, FilterIdx.I == N, FilterIdx.A == O {
+    public typealias S = M
+    public typealias I = N
+    public typealias A = O
+    
+    private let filterIndex : FilterIdx
+    private let iso : Iso<M, P>
+    
+    public init(filterIndex : FilterIdx, iso : Iso<M, P>) {
+        self.filterIndex = filterIndex
+        self.iso = iso
+    }
+    
+    public func filter(_ predicate: @escaping (N) -> Bool) -> Traversal<M, O> {
+        return iso + filterIndex.filter(predicate)
+    }
+}
+
+public class FilterIndexFromTraverse<M, N, Trav> : FilterIndex where Trav : Traverse, Trav.F == M {
+    public typealias S = Kind<M, N>
+    public typealias I = Int
+    public typealias A = N
+    
+    private let zipWithIndex : (Kind<M, N>) -> Kind<M, (N, Int)>
+    private let traverse : Trav
+    
+    public init(zipWithIndex : @escaping (Kind<M, N>) -> Kind<M, (N, Int)>, traverse : Trav) {
+        self.zipWithIndex = zipWithIndex
+        self.traverse = traverse
+    }
+    
+    public func filter(_ predicate: @escaping (Int) -> Bool) -> Traversal<Kind<M, N>, N> {
+        return FilterIndexFromTraverseTraversal(
+            zipWithIndex: zipWithIndex,
+            traverse: traverse,
+            predicate: predicate)
+    }
+}
+
+fileprivate class FilterIndexFromTraverseTraversal<S, A, Trav> : Traversal<Kind<S, A>, A> where Trav : Traverse, Trav.F == S {
+    
+    private let zipWithIndex : (Kind<S, A>) -> Kind<S, (A, Int)>
+    private let traverse : Trav
+    private let predicate : (Int) -> Bool
+    
+    init(zipWithIndex : @escaping (Kind<S, A>) -> Kind<S, (A, Int)>, traverse : Trav, predicate : @escaping (Int) -> Bool) {
+        self.zipWithIndex = zipWithIndex
+        self.traverse = traverse
+        self.predicate = predicate
+    }
+    
+    override func modifyF<Appl, F>(_ applicative: Appl, _ s: Kind<S, A>, _ f: @escaping (A) -> Kind<F, A>) -> Kind<F, Kind<S, A>> where Appl : Applicative, F == Appl.F {
+        return traverse.traverse(zipWithIndex(s), { x in
+            self.predicate(x.1) ? f(x.0) : applicative.pure(x.0)
+        }, applicative)
+    }
 }

--- a/Sources/Bow/Optics/Typeclasses/Index.swift
+++ b/Sources/Bow/Optics/Typeclasses/Index.swift
@@ -7,3 +7,31 @@ public protocol Index : Typeclass {
     
     func index(_ i : I) -> Optional<S, A>
 }
+
+public extension Index {
+    public static func index<Idx>(_ idx : Idx, _ i : I) -> Optional<S, A> where Idx : Index, Idx.S == S, Idx.I == I, Idx.A == A {
+        return idx.index(i)
+    }
+    
+    public static func fromIso<Idx, B>(_ idx : Idx, _ iso : Iso<S, A>) -> IndexFromIso<S, I, B, A, Idx> where Idx : Index, Idx.S == A, Idx.I == I, Idx.A == B {
+        return IndexFromIso(index: idx, iso: iso)
+    }
+}
+
+public class IndexFromIso<M, N, O, P, Idx> : Index where Idx : Index, Idx.S == P, Idx.I == N, Idx.A == O {
+    public typealias S = M
+    public typealias I = N
+    public typealias A = O
+    
+    private let idx : Idx
+    private let iso : Iso<M, P>
+    
+    public init(index : Idx, iso : Iso<M, P>) {
+        self.idx = index
+        self.iso = iso
+    }
+    
+    public func index(_ i: N) -> Optional<M, O> {
+        return iso + idx.index(i)
+    }
+}


### PR DESCRIPTION
This PR extends the existing typeclasses for optics (namely `At`, `Each`, `Index` and `FilterIndex`) with static methods to create implementations for them, from `Iso` and `Traverse`.