### PR TITLE
Improve test coverage

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -1120,7 +1120,6 @@
 				OBJ_60 /* Bifoldable.swift */,
 				OBJ_61 /* Bimonad.swift */,
 				OBJ_62 /* Comonad.swift */,
-				OBJ_63 /* Composed */,
 				OBJ_66 /* Eq.swift */,
 				OBJ_67 /* Foldable.swift */,
 				OBJ_68 /* Functor.swift */,
@@ -1143,6 +1142,7 @@
 				111082CB2085D9DD00C8563C /* Show.swift */,
 				OBJ_85 /* Traverse.swift */,
 				OBJ_86 /* TraverseFilter.swift */,
+				OBJ_63 /* Composed */,
 			);
 			path = Typeclasses;
 			sourceTree = "<group>";

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		111620AB20F6070200685EC4 /* FoldableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111620A620F606F300685EC4 /* FoldableLaws.swift */; };
 		111620AC20F6070200685EC4 /* FoldableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111620A620F606F300685EC4 /* FoldableLaws.swift */; };
 		111620AD20F6070300685EC4 /* FoldableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111620A620F606F300685EC4 /* FoldableLaws.swift */; };
+		111620B320F6137B00685EC4 /* BimonadLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111620AE20F6131E00685EC4 /* BimonadLaws.swift */; };
+		111620B420F6137B00685EC4 /* BimonadLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111620AE20F6131E00685EC4 /* BimonadLaws.swift */; };
+		111620B520F6137C00685EC4 /* BimonadLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111620AE20F6131E00685EC4 /* BimonadLaws.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -605,6 +608,7 @@
 		111082CB2085D9DD00C8563C /* Show.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Show.swift; sourceTree = "<group>"; };
 		111082D02085DD4D00C8563C /* ShowLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowLaws.swift; sourceTree = "<group>"; };
 		111620A620F606F300685EC4 /* FoldableLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableLaws.swift; sourceTree = "<group>"; };
+		111620AE20F6131E00685EC4 /* BimonadLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BimonadLaws.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -979,6 +983,7 @@
 			children = (
 				OBJ_125 /* ApplicativeErrorLaws.swift */,
 				OBJ_126 /* ApplicativeLaws.swift */,
+				111620AE20F6131E00685EC4 /* BimonadLaws.swift */,
 				OBJ_127 /* ComonadLaws.swift */,
 				OBJ_128 /* EqLaws.swift */,
 				111620A620F606F300685EC4 /* FoldableLaws.swift */,
@@ -1469,6 +1474,7 @@
 				D6D624472068141800739E2D /* KleisliTest.swift in Sources */,
 				D6D624482068141800739E2D /* BooleanFunctionsTest.swift in Sources */,
 				D6D624492068141800739E2D /* CurryTest.swift in Sources */,
+				111620B420F6137B00685EC4 /* BimonadLaws.swift in Sources */,
 				D6D6244A2068141800739E2D /* ConstTest.swift in Sources */,
 				D6D6244B2068141800739E2D /* CoproductTest.swift in Sources */,
 				D6D6244C2068141800739E2D /* EitherTest.swift in Sources */,
@@ -1628,6 +1634,7 @@
 				D6D62526206817A700739E2D /* KleisliTest.swift in Sources */,
 				D6D62527206817A700739E2D /* BooleanFunctionsTest.swift in Sources */,
 				D6D62528206817A700739E2D /* CurryTest.swift in Sources */,
+				111620B520F6137C00685EC4 /* BimonadLaws.swift in Sources */,
 				D6D62529206817A700739E2D /* ConstTest.swift in Sources */,
 				D6D6252A206817A700739E2D /* CoproductTest.swift in Sources */,
 				D6D6252B206817A700739E2D /* EitherTest.swift in Sources */,
@@ -1879,6 +1886,7 @@
 				OBJ_249 /* KleisliTest.swift in Sources */,
 				OBJ_250 /* BooleanFunctionsTest.swift in Sources */,
 				OBJ_251 /* CurryTest.swift in Sources */,
+				111620B320F6137B00685EC4 /* BimonadLaws.swift in Sources */,
 				OBJ_252 /* ConstTest.swift in Sources */,
 				OBJ_253 /* CoproductTest.swift in Sources */,
 				OBJ_254 /* EitherTest.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		11635BB220F64A20007BB4FA /* MonadCombineLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB120F64A20007BB4FA /* MonadCombineLaws.swift */; };
 		11635BB320F64A20007BB4FA /* MonadCombineLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB120F64A20007BB4FA /* MonadCombineLaws.swift */; };
 		11635BB420F64A20007BB4FA /* MonadCombineLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB120F64A20007BB4FA /* MonadCombineLaws.swift */; };
+		11635BB620F76131007BB4FA /* TraverseLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB520F76131007BB4FA /* TraverseLaws.swift */; };
+		11635BB720F76131007BB4FA /* TraverseLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB520F76131007BB4FA /* TraverseLaws.swift */; };
+		11635BB820F76131007BB4FA /* TraverseLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB520F76131007BB4FA /* TraverseLaws.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -617,6 +620,7 @@
 		111620AE20F6131E00685EC4 /* BimonadLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BimonadLaws.swift; sourceTree = "<group>"; };
 		11635BAD20F6464E007BB4FA /* AlternativeLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlternativeLaws.swift; sourceTree = "<group>"; };
 		11635BB120F64A20007BB4FA /* MonadCombineLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonadCombineLaws.swift; sourceTree = "<group>"; };
+		11635BB520F76131007BB4FA /* TraverseLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseLaws.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -1010,6 +1014,7 @@
 				OBJ_139 /* SemigroupKLaws.swift */,
 				OBJ_140 /* SemigroupLaws.swift */,
 				111082D02085DD4D00C8563C /* ShowLaws.swift */,
+				11635BB520F76131007BB4FA /* TraverseLaws.swift */,
 			);
 			path = Typeclasses;
 			sourceTree = "<group>";
@@ -1492,6 +1497,7 @@
 				11FE0067209C50D300183AF6 /* IsoLaws.swift in Sources */,
 				11FE0073209C6DEC00183AF6 /* PrismLaws.swift in Sources */,
 				D6D6244E2068141800739E2D /* IdTest.swift in Sources */,
+				11635BB720F76131007BB4FA /* TraverseLaws.swift in Sources */,
 				D6D6244F2068141800739E2D /* IorTest.swift in Sources */,
 				D6D624502068141800739E2D /* ListKTest.swift in Sources */,
 				D6D624512068141800739E2D /* MaybeTest.swift in Sources */,
@@ -1654,6 +1660,7 @@
 				11FE0068209C50D400183AF6 /* IsoLaws.swift in Sources */,
 				11FE0074209C6DEC00183AF6 /* PrismLaws.swift in Sources */,
 				D6D6252D206817A700739E2D /* IdTest.swift in Sources */,
+				11635BB820F76131007BB4FA /* TraverseLaws.swift in Sources */,
 				D6D6252E206817A700739E2D /* IorTest.swift in Sources */,
 				D6D6252F206817A700739E2D /* ListKTest.swift in Sources */,
 				D6D62530206817A700739E2D /* MaybeTest.swift in Sources */,
@@ -1908,6 +1915,7 @@
 				11FE0066209C50A700183AF6 /* IsoLaws.swift in Sources */,
 				11FE0072209C6DEC00183AF6 /* PrismLaws.swift in Sources */,
 				OBJ_256 /* IdTest.swift in Sources */,
+				11635BB620F76131007BB4FA /* TraverseLaws.swift in Sources */,
 				OBJ_257 /* IorTest.swift in Sources */,
 				OBJ_258 /* ListKTest.swift in Sources */,
 				OBJ_259 /* MaybeTest.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		11635BB620F76131007BB4FA /* TraverseLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB520F76131007BB4FA /* TraverseLaws.swift */; };
 		11635BB720F76131007BB4FA /* TraverseLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB520F76131007BB4FA /* TraverseLaws.swift */; };
 		11635BB820F76131007BB4FA /* TraverseLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB520F76131007BB4FA /* TraverseLaws.swift */; };
+		11635BBA20F77FE5007BB4FA /* TraverseFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */; };
+		11635BBB20F77FE5007BB4FA /* TraverseFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */; };
+		11635BBC20F77FE5007BB4FA /* TraverseFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -621,6 +624,7 @@
 		11635BAD20F6464E007BB4FA /* AlternativeLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlternativeLaws.swift; sourceTree = "<group>"; };
 		11635BB120F64A20007BB4FA /* MonadCombineLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonadCombineLaws.swift; sourceTree = "<group>"; };
 		11635BB520F76131007BB4FA /* TraverseLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseLaws.swift; sourceTree = "<group>"; };
+		11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseFilterLaws.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -1014,6 +1018,7 @@
 				OBJ_139 /* SemigroupKLaws.swift */,
 				OBJ_140 /* SemigroupLaws.swift */,
 				111082D02085DD4D00C8563C /* ShowLaws.swift */,
+				11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */,
 				11635BB520F76131007BB4FA /* TraverseLaws.swift */,
 			);
 			path = Typeclasses;
@@ -1513,6 +1518,7 @@
 				D6D6245A2068141800739E2D /* StringInstancesTest.swift in Sources */,
 				D6D6245B2068141800739E2D /* PartialApplicationTest.swift in Sources */,
 				D6D6245C2068141800739E2D /* PredefTest.swift in Sources */,
+				11635BBB20F77FE5007BB4FA /* TraverseFilterLaws.swift in Sources */,
 				11FE0082209C945900183AF6 /* IsoTest.swift in Sources */,
 				D6D6245D2068141800739E2D /* EitherTTest.swift in Sources */,
 				D6D6245E2068141800739E2D /* MaybeTTest.swift in Sources */,
@@ -1676,6 +1682,7 @@
 				D6D62539206817A700739E2D /* StringInstancesTest.swift in Sources */,
 				D6D6253A206817A700739E2D /* PartialApplicationTest.swift in Sources */,
 				D6D6253B206817A700739E2D /* PredefTest.swift in Sources */,
+				11635BBC20F77FE5007BB4FA /* TraverseFilterLaws.swift in Sources */,
 				11FE0083209C945900183AF6 /* IsoTest.swift in Sources */,
 				D6D6253C206817A700739E2D /* EitherTTest.swift in Sources */,
 				D6D6253D206817A700739E2D /* MaybeTTest.swift in Sources */,
@@ -1931,6 +1938,7 @@
 				OBJ_268 /* StringInstancesTest.swift in Sources */,
 				OBJ_269 /* PartialApplicationTest.swift in Sources */,
 				OBJ_270 /* PredefTest.swift in Sources */,
+				11635BBA20F77FE5007BB4FA /* TraverseFilterLaws.swift in Sources */,
 				11FE0081209C945900183AF6 /* IsoTest.swift in Sources */,
 				OBJ_271 /* EitherTTest.swift in Sources */,
 				OBJ_272 /* MaybeTTest.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -12,6 +12,9 @@
 		111082CE2085DBF800C8563C /* Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082CB2085D9DD00C8563C /* Show.swift */; };
 		111082CF2085DBF800C8563C /* Show.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082CB2085D9DD00C8563C /* Show.swift */; };
 		111082D12085DD4D00C8563C /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
+		111620AB20F6070200685EC4 /* FoldableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111620A620F606F300685EC4 /* FoldableLaws.swift */; };
+		111620AC20F6070200685EC4 /* FoldableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111620A620F606F300685EC4 /* FoldableLaws.swift */; };
+		111620AD20F6070300685EC4 /* FoldableLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111620A620F606F300685EC4 /* FoldableLaws.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -601,6 +604,7 @@
 /* Begin PBXFileReference section */
 		111082CB2085D9DD00C8563C /* Show.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Show.swift; sourceTree = "<group>"; };
 		111082D02085DD4D00C8563C /* ShowLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowLaws.swift; sourceTree = "<group>"; };
+		111620A620F606F300685EC4 /* FoldableLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableLaws.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -977,6 +981,7 @@
 				OBJ_126 /* ApplicativeLaws.swift */,
 				OBJ_127 /* ComonadLaws.swift */,
 				OBJ_128 /* EqLaws.swift */,
+				111620A620F606F300685EC4 /* FoldableLaws.swift */,
 				OBJ_129 /* FunctorFilterLaws.swift */,
 				OBJ_130 /* FunctorLaws.swift */,
 				OBJ_131 /* MonadErrorLaws.swift */,
@@ -1493,6 +1498,7 @@
 				D6D624602068141800739E2D /* WriterTTest.swift in Sources */,
 				11FE0086209C976F00183AF6 /* LensTest.swift in Sources */,
 				D6D624612068141800739E2D /* ApplicativeErrorLaws.swift in Sources */,
+				111620AC20F6070200685EC4 /* FoldableLaws.swift in Sources */,
 				D6D624622068141800739E2D /* ApplicativeLaws.swift in Sources */,
 				D6D624632068141800739E2D /* ComonadLaws.swift in Sources */,
 				D6D624642068141800739E2D /* EqLaws.swift in Sources */,
@@ -1651,6 +1657,7 @@
 				D6D6253F206817A700739E2D /* WriterTTest.swift in Sources */,
 				11FE0087209C976F00183AF6 /* LensTest.swift in Sources */,
 				D6D62540206817A700739E2D /* ApplicativeErrorLaws.swift in Sources */,
+				111620AD20F6070300685EC4 /* FoldableLaws.swift in Sources */,
 				D6D62541206817A700739E2D /* ApplicativeLaws.swift in Sources */,
 				D6D62542206817A700739E2D /* ComonadLaws.swift in Sources */,
 				D6D62543206817A700739E2D /* EqLaws.swift in Sources */,
@@ -1901,6 +1908,7 @@
 				OBJ_274 /* WriterTTest.swift in Sources */,
 				11FE0085209C976F00183AF6 /* LensTest.swift in Sources */,
 				OBJ_275 /* ApplicativeErrorLaws.swift in Sources */,
+				111620AB20F6070200685EC4 /* FoldableLaws.swift in Sources */,
 				OBJ_276 /* ApplicativeLaws.swift in Sources */,
 				OBJ_277 /* ComonadLaws.swift in Sources */,
 				OBJ_278 /* EqLaws.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -18,6 +18,9 @@
 		111620B320F6137B00685EC4 /* BimonadLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111620AE20F6131E00685EC4 /* BimonadLaws.swift */; };
 		111620B420F6137B00685EC4 /* BimonadLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111620AE20F6131E00685EC4 /* BimonadLaws.swift */; };
 		111620B520F6137C00685EC4 /* BimonadLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111620AE20F6131E00685EC4 /* BimonadLaws.swift */; };
+		11635BAE20F6464E007BB4FA /* AlternativeLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BAD20F6464E007BB4FA /* AlternativeLaws.swift */; };
+		11635BAF20F6464E007BB4FA /* AlternativeLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BAD20F6464E007BB4FA /* AlternativeLaws.swift */; };
+		11635BB020F6464E007BB4FA /* AlternativeLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BAD20F6464E007BB4FA /* AlternativeLaws.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -609,6 +612,7 @@
 		111082D02085DD4D00C8563C /* ShowLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShowLaws.swift; sourceTree = "<group>"; };
 		111620A620F606F300685EC4 /* FoldableLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableLaws.swift; sourceTree = "<group>"; };
 		111620AE20F6131E00685EC4 /* BimonadLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BimonadLaws.swift; sourceTree = "<group>"; };
+		11635BAD20F6464E007BB4FA /* AlternativeLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlternativeLaws.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -981,6 +985,7 @@
 		OBJ_124 /* Typeclasses */ = {
 			isa = PBXGroup;
 			children = (
+				11635BAD20F6464E007BB4FA /* AlternativeLaws.swift */,
 				OBJ_125 /* ApplicativeErrorLaws.swift */,
 				OBJ_126 /* ApplicativeLaws.swift */,
 				111620AE20F6131E00685EC4 /* BimonadLaws.swift */,
@@ -1506,6 +1511,7 @@
 				D6D624612068141800739E2D /* ApplicativeErrorLaws.swift in Sources */,
 				111620AC20F6070200685EC4 /* FoldableLaws.swift in Sources */,
 				D6D624622068141800739E2D /* ApplicativeLaws.swift in Sources */,
+				11635BAF20F6464E007BB4FA /* AlternativeLaws.swift in Sources */,
 				D6D624632068141800739E2D /* ComonadLaws.swift in Sources */,
 				D6D624642068141800739E2D /* EqLaws.swift in Sources */,
 				D6D624652068141800739E2D /* FunctorFilterLaws.swift in Sources */,
@@ -1666,6 +1672,7 @@
 				D6D62540206817A700739E2D /* ApplicativeErrorLaws.swift in Sources */,
 				111620AD20F6070300685EC4 /* FoldableLaws.swift in Sources */,
 				D6D62541206817A700739E2D /* ApplicativeLaws.swift in Sources */,
+				11635BB020F6464E007BB4FA /* AlternativeLaws.swift in Sources */,
 				D6D62542206817A700739E2D /* ComonadLaws.swift in Sources */,
 				D6D62543206817A700739E2D /* EqLaws.swift in Sources */,
 				D6D62544206817A700739E2D /* FunctorFilterLaws.swift in Sources */,
@@ -1918,6 +1925,7 @@
 				OBJ_275 /* ApplicativeErrorLaws.swift in Sources */,
 				111620AB20F6070200685EC4 /* FoldableLaws.swift in Sources */,
 				OBJ_276 /* ApplicativeLaws.swift in Sources */,
+				11635BAE20F6464E007BB4FA /* AlternativeLaws.swift in Sources */,
 				OBJ_277 /* ComonadLaws.swift in Sources */,
 				OBJ_278 /* EqLaws.swift in Sources */,
 				OBJ_279 /* FunctorFilterLaws.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -21,6 +21,9 @@
 		11635BAE20F6464E007BB4FA /* AlternativeLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BAD20F6464E007BB4FA /* AlternativeLaws.swift */; };
 		11635BAF20F6464E007BB4FA /* AlternativeLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BAD20F6464E007BB4FA /* AlternativeLaws.swift */; };
 		11635BB020F6464E007BB4FA /* AlternativeLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BAD20F6464E007BB4FA /* AlternativeLaws.swift */; };
+		11635BB220F64A20007BB4FA /* MonadCombineLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB120F64A20007BB4FA /* MonadCombineLaws.swift */; };
+		11635BB320F64A20007BB4FA /* MonadCombineLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB120F64A20007BB4FA /* MonadCombineLaws.swift */; };
+		11635BB420F64A20007BB4FA /* MonadCombineLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB120F64A20007BB4FA /* MonadCombineLaws.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -613,6 +616,7 @@
 		111620A620F606F300685EC4 /* FoldableLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoldableLaws.swift; sourceTree = "<group>"; };
 		111620AE20F6131E00685EC4 /* BimonadLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BimonadLaws.swift; sourceTree = "<group>"; };
 		11635BAD20F6464E007BB4FA /* AlternativeLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlternativeLaws.swift; sourceTree = "<group>"; };
+		11635BB120F64A20007BB4FA /* MonadCombineLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonadCombineLaws.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -994,6 +998,7 @@
 				111620A620F606F300685EC4 /* FoldableLaws.swift */,
 				OBJ_129 /* FunctorFilterLaws.swift */,
 				OBJ_130 /* FunctorLaws.swift */,
+				11635BB120F64A20007BB4FA /* MonadCombineLaws.swift */,
 				OBJ_131 /* MonadErrorLaws.swift */,
 				OBJ_132 /* MonadFilterLaws.swift */,
 				OBJ_133 /* MonadLaws.swift */,
@@ -1528,6 +1533,7 @@
 				D6D6246D2068141800739E2D /* MonoidLaws.swift in Sources */,
 				D6D6246E2068141800739E2D /* OrderLaws.swift in Sources */,
 				11C9B6B720DBB34D00AFD4AA /* TraversalLaws.swift in Sources */,
+				11635BB320F64A20007BB4FA /* MonadCombineLaws.swift in Sources */,
 				11FE0093209C9C3300183AF6 /* PrismTest.swift in Sources */,
 				11FE007E209C8F9400183AF6 /* TestDomain.swift in Sources */,
 				D6D6246F2068141800739E2D /* SemigroupKLaws.swift in Sources */,
@@ -1689,6 +1695,7 @@
 				D6D6254C206817A700739E2D /* MonoidLaws.swift in Sources */,
 				D6D6254D206817A700739E2D /* OrderLaws.swift in Sources */,
 				11C9B6B820DBB34D00AFD4AA /* TraversalLaws.swift in Sources */,
+				11635BB420F64A20007BB4FA /* MonadCombineLaws.swift in Sources */,
 				11FE0094209C9C3300183AF6 /* PrismTest.swift in Sources */,
 				11FE007F209C8F9400183AF6 /* TestDomain.swift in Sources */,
 				D6D6254E206817A700739E2D /* SemigroupKLaws.swift in Sources */,
@@ -1942,6 +1949,7 @@
 				OBJ_287 /* MonoidLaws.swift in Sources */,
 				OBJ_288 /* OrderLaws.swift in Sources */,
 				11C9B6B620DBB34C00AFD4AA /* TraversalLaws.swift in Sources */,
+				11635BB220F64A20007BB4FA /* MonadCombineLaws.swift in Sources */,
 				11FE0092209C9C3300183AF6 /* PrismTest.swift in Sources */,
 				11FE007D209C8F9400183AF6 /* TestDomain.swift in Sources */,
 				OBJ_289 /* SemigroupKLaws.swift in Sources */,

--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -27,7 +27,7 @@ public class Const<A, T> : ConstOf<A, T> {
         return applicative.pure(retag())
     }
     
-    public func traverseFilter<F, U, Appl>(_ f : (T) -> Kind<F, Maybe<U>>, _ applicative : Appl) -> Kind<F, ConstOf<A, U>> where Appl : Applicative, Appl.F == F {
+    public func traverseFilter<F, U, Appl>(_ f : (T) -> Kind<F, MaybeOf<U>>, _ applicative : Appl) -> Kind<F, ConstOf<A, U>> where Appl : Applicative, Appl.F == F {
         return applicative.pure(retag())
     }
     
@@ -149,7 +149,7 @@ public class ConstTraverse<R> : ConstFoldable<R>, Traverse {
 }
 
 public class ConstTraverseFilter<R> : ConstTraverse<R>, TraverseFilter {
-    public func traverseFilter<A, B, G, Appl>(_ fa: ConstOf<R, A>, _ f: @escaping (A) -> Kind<G, Maybe<B>>, _ applicative: Appl) -> Kind<G, ConstOf<R, B>> where G == Appl.F, Appl : Applicative {
+    public func traverseFilter<A, B, G, Appl>(_ fa: ConstOf<R, A>, _ f: @escaping (A) -> Kind<G, MaybeOf<B>>, _ applicative: Appl) -> Kind<G, ConstOf<R, B>> where G == Appl.F, Appl : Applicative {
         return Const.fix(fa).traverseFilter(f, applicative)
     }
 }

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -41,7 +41,7 @@ public class Either<A, B> : EitherOf<A, B> {
     }
     
     public var isLeft : Bool {
-        return fold(constF(true), constF(false))
+        return fold(constant(true), constant(false))
     }
     
     public var isRight : Bool {
@@ -49,11 +49,11 @@ public class Either<A, B> : EitherOf<A, B> {
     }
     
     public func foldL<C>(_ c : C, _ f : (C, B) -> C) -> C {
-        return fold(constF(c), { b in f(c, b) })
+        return fold(constant(c), { b in f(c, b) })
     }
     
     public func foldR<C>(_ c : Eval<C>, _ f : (B, Eval<C>) -> Eval<C>) -> Eval<C> {
-        return fold(constF(c), { b in f(b, c) })
+        return fold(constant(c), { b in f(b, c) })
     }
     
     public func swap() -> Either<B, A> {
@@ -79,15 +79,15 @@ public class Either<A, B> : EitherOf<A, B> {
     }
     
     public func exists(_ predicate : (B) -> Bool) -> Bool {
-        return fold(constF(false), predicate)
+        return fold(constant(false), predicate)
     }
     
     public func toMaybe() -> Maybe<B> {
-        return fold(constF(Maybe<B>.none()), Maybe<B>.some)
+        return fold(constant(Maybe<B>.none()), Maybe<B>.some)
     }
     
     public func getOrElse(_ defaultValue : B) -> B {
-        return fold(constF(defaultValue), id)
+        return fold(constant(defaultValue), id)
     }
     
     public func filterOrElse(_ predicate : @escaping (B) -> Bool, _ defaultValue : A) -> Either<A, B> {
@@ -103,7 +103,7 @@ public class Either<A, B> : EitherOf<A, B> {
     }
     
     public func combineK(_ y : Either<A, B>) -> Either<A, B> {
-        return fold(constF(y), Either<A, B>.right)
+        return fold(constant(y), Either<A, B>.right)
     }
 }
 
@@ -194,7 +194,7 @@ public class EitherMonadError<C> : EitherMonad<C>, MonadError {
     }
     
     public func handleErrorWith<A>(_ fa: EitherOf<C, A>, _ f: @escaping (C) -> EitherOf<C, A>) -> EitherOf<C, A> {
-        return Either.fix(fa).fold(f, constF(Either.fix(fa)))
+        return Either.fix(fa).fold(f, constant(Either.fix(fa)))
     }
 }
 
@@ -235,7 +235,7 @@ public class EitherEq<L, R, EqL, EqR> : Eq where EqL : Eq, EqL.A == L, EqR : Eq,
     }
     
     public func eqv(_ a: EitherOf<L, R>, _ b: EitherOf<L, R>) -> Bool {
-        return Either.fix(a).fold({ aLeft  in Either.fix(b).fold({ bLeft in eql.eqv(aLeft, bLeft) }, constF(false)) },
-                                 { aRight in Either.fix(b).fold(constF(false), { bRight in eqr.eqv(aRight, bRight) }) })
+        return Either.fix(a).fold({ aLeft  in Either.fix(b).fold({ bLeft in eql.eqv(aLeft, bLeft) }, constant(false)) },
+                                 { aRight in Either.fix(b).fold(constant(false), { bRight in eqr.eqv(aRight, bRight) }) })
     }
 }

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -66,25 +66,25 @@ public class Ior<A, B> : IorOf<A, B> {
     }
     
     public var isLeft : Bool {
-        return fold(constF(true), constF(false), constF(false))
+        return fold(constant(true), constant(false), constant(false))
     }
     
     public var isRight : Bool {
-        return fold(constF(false), constF(true), constF(false))
+        return fold(constant(false), constant(true), constant(false))
     }
     
     public var isBoth : Bool {
-        return fold(constF(false), constF(false), constF(true))
+        return fold(constant(false), constant(false), constant(true))
     }
     
     public func foldL<C>(_ c : C, _ f : (C, B) -> C) -> C {
-        return fold(constF(c),
+        return fold(constant(c),
                     { b in f(c, b) },
                     { _, b in f(c, b) })
     }
     
     public func foldR<C>(_ c : Eval<C>, _ f : (B, Eval<C>) -> Eval<C>) -> Eval<C> {
-        return fold(constF(c),
+        return fold(constant(c),
                     { b in f(b, c) },
                     { _, b in f(b, c) })
     }
@@ -157,7 +157,7 @@ public class Ior<A, B> : IorOf<A, B> {
     }
     
     public func getOrElse(_ defaultValue : B) -> B {
-        return fold(constF(defaultValue),
+        return fold(constant(defaultValue),
                     id,
                     { _, b in b })
     }
@@ -291,13 +291,13 @@ public class IorEq<L, R, EqL, EqR> : Eq where EqL : Eq, EqL.A == L, EqR : Eq, Eq
         let a = Ior.fix(a)
         let b = Ior.fix(b)
         return a.fold({ aLeft in
-            b.fold({ bLeft in eql.eqv(aLeft, bLeft) }, constF(false), constF(false))
+            b.fold({ bLeft in eql.eqv(aLeft, bLeft) }, constant(false), constant(false))
         },
                       { aRight in
-            b.fold(constF(false), { bRight in eqr.eqv(aRight, bRight) }, constF(false))
+            b.fold(constant(false), { bRight in eqr.eqv(aRight, bRight) }, constant(false))
         },
                       { aLeft, aRight in
-            b.fold(constF(false), constF(false), { bLeft, bRight in eql.eqv(aLeft, bLeft) && eqr.eqv(aRight, bRight)})
+            b.fold(constant(false), constant(false), { bLeft, bRight in eql.eqv(aLeft, bLeft) && eqr.eqv(aRight, bRight)})
         })
     }
 }

--- a/Sources/Bow/Data/ListK.swift
+++ b/Sources/Bow/Data/ListK.swift
@@ -26,9 +26,8 @@ public class ListK<A> : ListKOf<A> {
                             let newBuf = buf + [b]
                             return go(newBuf, f, ListK<Either<A, B>>([Either<A, B>](v.list.dropFirst())))
                       })
-        } else {
-            return buf
         }
+        return buf
     }
     
     public static func tailRecM<B>(_ a : A, _ f : (A) -> ListKOf<Either<A, B>>) -> ListK<B> {
@@ -101,11 +100,8 @@ public class ListK<A> : ListKOf<A> {
     }
     
     public func firstOrNone() -> Maybe<A> {
-        if let first = self.list.first {
-            return Maybe.some(first)
-        } else {
-            return Maybe.none()
-        }
+        if let first = asArray.first { return Maybe.some(first) }
+        return Maybe.none()
     }
 }
 

--- a/Sources/Bow/Data/ListK.swift
+++ b/Sources/Bow/Data/ListK.swift
@@ -91,8 +91,8 @@ public class ListK<A> : ListKOf<A> {
         }
     }
     
-    public func mapFilter<B>(_ f : (A) -> Maybe<B>) -> ListK<B> {
-        return flatMap { a in f(a).fold(ListK<B>.empty, ListK<B>.pure) }
+    public func mapFilter<B>(_ f : (A) -> MaybeOf<B>) -> ListK<B> {
+        return flatMap { a in f(a).fix().fold(ListK<B>.empty, ListK<B>.pure) }
     }
     
     public func combineK(_ y : ListK<A>) -> ListK<A> {
@@ -232,7 +232,7 @@ public class ListKMonoidK : ListKSemigroupK, MonoidK {
 }
 
 public class ListKFunctorFilter : ListKFunctor, FunctorFilter {
-    public func mapFilter<A, B>(_ fa: ListKOf<A>, _ f: @escaping (A) -> Maybe<B>) -> ListKOf<B> {
+    public func mapFilter<A, B>(_ fa: ListKOf<A>, _ f: @escaping (A) -> MaybeOf<B>) -> ListKOf<B> {
         return fa.fix().mapFilter(f)
     }
 }
@@ -242,7 +242,7 @@ public class ListKMonadFilter : ListKMonad, MonadFilter {
         return ListK<A>.empty()
     }
     
-    public func mapFilter<A, B>(_ fa: ListKOf<A>, _ f: @escaping (A) -> Maybe<B>) -> ListKOf<B> {
+    public func mapFilter<A, B>(_ fa: ListKOf<A>, _ f: @escaping (A) -> MaybeOf<B>) -> ListKOf<B> {
         return fa.fix().mapFilter(f)
     }
 }

--- a/Sources/Bow/Data/Maybe.swift
+++ b/Sources/Bow/Data/Maybe.swift
@@ -21,11 +21,8 @@ public class Maybe<A> : MaybeOf<A> {
     }
     
     public static func fromOption(_ a : A?) -> Maybe<A> {
-        if let a = a {
-            return some(a)
-        } else {
-            return none()
-        }
+        if let a = a { return some(a) }
+        return none()
     }
     
     public static func tailRecM<B>(_ a : A, _ f : (A) -> Maybe<Either<A, B>>) -> Maybe<B> {
@@ -98,7 +95,7 @@ public class Maybe<A> : MaybeOf<A> {
     }
     
     public func filter(_ predicate : (A) -> Bool) -> Maybe<A> {
-        return fold({ Maybe<A>.none() },
+        return fold(constant(Maybe<A>.none()),
                     { a in predicate(a) ? Maybe<A>.some(a) : Maybe<A>.none() })
     }
     
@@ -107,7 +104,7 @@ public class Maybe<A> : MaybeOf<A> {
     }
     
     public func exists(_ predicate : (A) -> Bool) -> Bool {
-        return fold({ false }, predicate)
+        return fold(constant(false), predicate)
     }
     
     public func forall(_ predicate : (A) -> Bool) -> Bool {
@@ -131,7 +128,7 @@ public class Maybe<A> : MaybeOf<A> {
     }
     
     public func toOption() -> A? {
-        return fold({ nil }, id)
+        return fold(constant(nil), id)
     }
 }
 

--- a/Sources/Bow/Data/Maybe.swift
+++ b/Sources/Bow/Data/Maybe.swift
@@ -29,7 +29,7 @@ public class Maybe<A> : MaybeOf<A> {
     }
     
     public static func tailRecM<B>(_ a : A, _ f : (A) -> Maybe<Either<A, B>>) -> Maybe<B> {
-        return f(a).fold(constF(Maybe<B>.none()),
+        return f(a).fold(constant(Maybe<B>.none()),
                          { either in
                             either.fold({ left in tailRecM(left, f) },
                                         Maybe<B>.some)
@@ -80,7 +80,7 @@ public class Maybe<A> : MaybeOf<A> {
     }
     
     public func foldR<B>(_ b : Eval<B>, _ f : (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return self.fold(constF(b),
+        return self.fold(constant(b),
                          { a in f(a, b) })
     }
     
@@ -115,7 +115,7 @@ public class Maybe<A> : MaybeOf<A> {
     }
     
     public func getOrElse(_ defaultValue : A) -> A {
-        return getOrElse(constF(defaultValue))
+        return getOrElse(constant(defaultValue))
     }
     
     public func getOrElse(_ defaultValue : () -> A) -> A {
@@ -123,7 +123,7 @@ public class Maybe<A> : MaybeOf<A> {
     }
     
     public func orElse(_ defaultValue : Maybe<A>) -> Maybe<A> {
-        return orElse(constF(defaultValue))
+        return orElse(constant(defaultValue))
     }
     
     public func orElse(_ defaultValue : () -> Maybe<A>) -> Maybe<A> {
@@ -235,8 +235,8 @@ public class MaybeSemigroup<R, SemiG> : Semigroup where SemiG : Semigroup, SemiG
     public func combine(_ a: MaybeOf<R>, _ b: MaybeOf<R>) -> MaybeOf<R> {
         let a = Maybe.fix(a)
         let b = Maybe.fix(b)
-        return a.fold(constF(b),
-                      { aSome in b.fold(constF(a),
+        return a.fold(constant(b),
+                      { aSome in b.fold(constant(a),
                                         { bSome in Maybe.some(semigroup.combine(aSome, bSome)) })
                       })
     }
@@ -272,8 +272,8 @@ public class MaybeEq<R, EqR> : Eq where EqR : Eq, EqR.A == R {
     public func eqv(_ a: MaybeOf<R>, _ b: MaybeOf<R>) -> Bool {
         let a = Maybe.fix(a)
         let b = Maybe.fix(b)
-        return a.fold({ b.fold(constF(true), constF(false)) },
-                      { aSome in b.fold(constF(false), { bSome in eqr.eqv(aSome, bSome) })})
+        return a.fold({ b.fold(constant(true), constant(false)) },
+                      { aSome in b.fold(constant(false), { bSome in eqr.eqv(aSome, bSome) })})
     }
 }
 

--- a/Sources/Bow/Data/Maybe.swift
+++ b/Sources/Bow/Data/Maybe.swift
@@ -195,6 +195,10 @@ public extension Maybe {
     public static func foldable() -> MaybeFoldable {
         return MaybeFoldable()
     }
+    
+    public static func traverse() -> MaybeTraverse {
+        return MaybeTraverse()
+    }
 }
 
 public class MaybeFunctor : Functor {
@@ -299,5 +303,11 @@ public class MaybeFoldable : Foldable {
     
     public func foldR<A, B>(_ fa: Kind<ForMaybe, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         return fa.fix().foldR(b, f)
+    }
+}
+
+public class MaybeTraverse : MaybeFoldable, Traverse {
+    public func traverse<G, A, B, Appl>(_ fa: Kind<ForMaybe, A>, _ f: @escaping (A) -> Kind<G, B>, _ applicative: Appl) -> Kind<G, Kind<ForMaybe, B>> where G == Appl.F, Appl : Applicative {
+        return fa.fix().traverse(f, applicative)
     }
 }

--- a/Sources/Bow/Data/Maybe.swift
+++ b/Sources/Bow/Data/Maybe.swift
@@ -194,6 +194,10 @@ public extension Maybe {
     public static func monadFilter() -> MaybeMonadFilter {
         return MaybeMonadFilter()
     }
+    
+    public static func foldable() -> MaybeFoldable {
+        return MaybeFoldable()
+    }
 }
 
 public class MaybeFunctor : Functor {
@@ -286,5 +290,17 @@ public class MaybeFunctorFilter : MaybeFunctor, FunctorFilter {
 public class MaybeMonadFilter : MaybeMonad, MonadFilter {
     public func empty<A>() -> MaybeOf<A> {
         return Maybe.empty()
+    }
+}
+
+public class MaybeFoldable : Foldable {
+    public typealias F = ForMaybe
+    
+    public func foldL<A, B>(_ fa: Kind<ForMaybe, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return fa.fix().foldL(b, f)
+    }
+    
+    public func foldR<A, B>(_ fa: Kind<ForMaybe, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return fa.fix().foldR(b, f)
     }
 }

--- a/Sources/Bow/Data/Maybe.swift
+++ b/Sources/Bow/Data/Maybe.swift
@@ -85,7 +85,7 @@ public class Maybe<A> : MaybeOf<A> {
         return self.fold(Maybe<B>.none, f)
     }
     
-    public func traverse<G, B, Appl>(_ f : (A) -> Kind<G, B>, _ applicative : Appl) -> Kind<G, Maybe<B>> where Appl : Applicative, Appl.F == G {
+    public func traverse<G, B, Appl>(_ f : (A) -> Kind<G, B>, _ applicative : Appl) -> Kind<G, MaybeOf<B>> where Appl : Applicative, Appl.F == G {
         return fold({ applicative.pure(Maybe<B>.none()) },
                     { a in applicative.map(f(a), Maybe<B>.some)})
     }

--- a/Sources/Bow/Data/NonEmptyList.swift
+++ b/Sources/Bow/Data/NonEmptyList.swift
@@ -96,9 +96,8 @@ public class NonEmptyList<A> : NonEmptyListOf<A> {
     }
     
     public func traverse<G, B, Appl>(_ f : @escaping (A) -> Kind<G, B>, _ applicative : Appl) -> Kind<G, NonEmptyListOf<B>> where Appl : Applicative, Appl.F == G {
-        return applicative.map2Eval(f(self.head),
-                                    Eval<Kind<G, ListKOf<B>>>.always({ ListK<A>.traverse().traverse(ListK<A>(self.tail), f, applicative) }),
-                                    { (a : B, b : ListKOf<B>) in NonEmptyList<B>(head: a, tail: b.fix().asArray) }).value()
+        let listTraverse = ListK<A>.traverse().traverse(self.all().k(), f, applicative)
+        return applicative.map(listTraverse, { x in NonEmptyList<B>.fromArrayUnsafe(x.fix().asArray) })
     }
     
     public func coflatMap<B>(_ f : @escaping (NonEmptyList<A>) -> B) -> NonEmptyList<B> {
@@ -280,13 +279,3 @@ public class NonEmptyListEq<R, EqR> : Eq where EqR : Eq, EqR.A == R {
         }
     }
 }
-
-
-
-
-
-
-
-
-
-

--- a/Sources/Bow/Data/State.swift
+++ b/Sources/Bow/Data/State.swift
@@ -7,7 +7,7 @@ public class State<S, A> : StateT<ForId, S, A> {
     }
     
     public func run(_ initial : S) -> (S, A) {
-        return (self.run(initial, Id<S>.monad()) as! Id<(S, A)>).extract()
+        return self.run(initial, Id<S>.monad()).fix().extract()
     }
     
     public func runA(_ s : S) -> A {

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -63,12 +63,12 @@ public class Try<A> : TryOf<A> {
     }
     
     public func foldL<B>(_ b : B, _ f : (B, A) -> B) -> B {
-        return fold(constF(b),
+        return fold(constant(b),
                     { a in f(b, a) })
     }
     
     public func foldR<B>(_ lb : Eval<B>, _ f : (A, Eval<B>) -> Eval<B>) -> Eval<B> {
-        return fold(constF(lb),
+        return fold(constant(lb),
                     { a in f(a, lb) })
     }
     
@@ -103,7 +103,7 @@ public class Try<A> : TryOf<A> {
     }
     
     public func getOrElse(_ defaultValue : A) -> A {
-        return fold(constF(defaultValue), id)
+        return fold(constant(defaultValue), id)
     }
     
     public func recoverWith(_ f : (Error) -> Try<A>) -> Try<A> {
@@ -221,7 +221,7 @@ public class TryEq<R, EqR> : Eq where EqR : Eq, EqR.A == R {
     public func eqv(_ a: TryOf<R>, _ b: TryOf<R>) -> Bool {
         let a = Try.fix(a)
         let b = Try.fix(b)
-        return a.fold({ aError in b.fold({ bError in "\(aError)" == "\(bError)" }, constF(false))},
-                      { aSuccess in b.fold(constF(false), { bSuccess in eqr.eqv(aSuccess, bSuccess)})})
+        return a.fold({ aError in b.fold({ bError in "\(aError)" == "\(bError)" }, constant(false))},
+                      { aSuccess in b.fold(constant(false), { bSuccess in eqr.eqv(aSuccess, bSuccess)})})
     }
 }

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -72,7 +72,7 @@ public class Try<A> : TryOf<A> {
                     { a in f(a, lb) })
     }
     
-    public func traverse<G, B, Appl>(_ f : (A) -> Kind<G, B>, _ applicative : Appl) -> Kind<G, Try<B>> where Appl : Applicative, Appl.F == G {
+    public func traverse<G, B, Appl>(_ f : (A) -> Kind<G, B>, _ applicative : Appl) -> Kind<G, TryOf<B>> where Appl : Applicative, Appl.F == G {
         return fold({ _ in applicative.pure(Try<B>.raise(TryError.illegalState)) },
                     { a in applicative.map(f(a), { b in Try<B>.invoke{ b } }) })
     }
@@ -172,6 +172,10 @@ public extension Try {
     public static func foldable() -> TryFoldable {
         return TryFoldable()
     }
+    
+    public static func traverse() -> TryTraverse {
+        return TryTraverse()
+    }
 }
 
 public class TryFunctor : Functor {
@@ -239,5 +243,11 @@ public class TryFoldable : Foldable {
     
     public func foldR<A, B>(_ fa: Kind<ForTry, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
         return fa.fix().foldR(b, f)
+    }
+}
+
+public class TryTraverse : TryFoldable, Traverse {
+    public func traverse<G, A, B, Appl>(_ fa: Kind<ForTry, A>, _ f: @escaping (A) -> Kind<G, B>, _ applicative: Appl) -> Kind<G, Kind<ForTry, B>> where G == Appl.F, Appl : Applicative {
+        return fa.fix().traverse(f, applicative)
     }
 }

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -168,6 +168,10 @@ public extension Try {
     public static func eq<EqA>(_ eqa : EqA) -> TryEq<A, EqA> {
         return TryEq<A, EqA>(eqa)
     }
+    
+    public static func foldable() -> TryFoldable {
+        return TryFoldable()
+    }
 }
 
 public class TryFunctor : Functor {
@@ -223,5 +227,17 @@ public class TryEq<R, EqR> : Eq where EqR : Eq, EqR.A == R {
         let b = Try.fix(b)
         return a.fold({ aError in b.fold({ bError in "\(aError)" == "\(bError)" }, constant(false))},
                       { aSuccess in b.fold(constant(false), { bSuccess in eqr.eqv(aSuccess, bSuccess)})})
+    }
+}
+
+public class TryFoldable : Foldable {
+    public typealias F = ForTry
+    
+    public func foldL<A, B>(_ fa: Kind<ForTry, A>, _ b: B, _ f: @escaping (B, A) -> B) -> B {
+        return fa.fix().foldL(b, f)
+    }
+    
+    public func foldR<A, B>(_ fa: Kind<ForTry, A>, _ b: Eval<B>, _ f: @escaping (A, Eval<B>) -> Eval<B>) -> Eval<B> {
+        return fa.fix().foldR(b, f)
     }
 }

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -45,7 +45,7 @@ public class Validated<E, A> : ValidatedOf<E, A> {
     }
     
     public var isValid : Bool {
-        return fold(constF(false), constF(true))
+        return fold(constant(false), constant(true))
     }
     
     public var isInvalid : Bool {
@@ -53,7 +53,7 @@ public class Validated<E, A> : ValidatedOf<E, A> {
     }
     
     public func exists(_ predicate : (A) -> Bool) -> Bool {
-        return fold(constF(false), predicate)
+        return fold(constant(false), predicate)
     }
     
     public func toEither() -> Either<E, A> {
@@ -61,11 +61,11 @@ public class Validated<E, A> : ValidatedOf<E, A> {
     }
     
     public func toMaybe() -> Maybe<A> {
-        return fold(constF(Maybe.none()), Maybe.some)
+        return fold(constant(Maybe.none()), Maybe.some)
     }
     
     public func toList() -> [A] {
-        return fold(constF([]), { a in [a] })
+        return fold(constant([]), { a in [a] })
     }
     
     public func withEither<EE, B>(_ f : (Either<E, A>) -> Either<EE, B>) -> Validated<EE, B> {
@@ -93,11 +93,11 @@ public class Validated<E, A> : ValidatedOf<E, A> {
     }
     
     public func foldL<B>(_ b : B, _ f : (B, A) -> B) -> B {
-        return fold(constF(b), { a in f(b, a) })
+        return fold(constant(b), { a in f(b, a) })
     }
     
     public func foldR<B>(_ b : Eval<B>, _ f : (A, Eval<B>) -> Eval<B>) -> Eval<B>{
-        return fold(constF(b), { a in f(a, b) })
+        return fold(constant(b), { a in f(a, b) })
     }
     
     public func swap() -> Validated<A, E> {
@@ -105,7 +105,7 @@ public class Validated<E, A> : ValidatedOf<E, A> {
     }
     
     public func getOrElse(_ defaultValue : A) -> A {
-        return fold(constF(defaultValue), id)
+        return fold(constant(defaultValue), id)
     }
     
     public func valueOr(_ f : (E) -> A) -> A {
@@ -119,7 +119,7 @@ public class Validated<E, A> : ValidatedOf<E, A> {
     }
     
     public func orElse(_ defaultValue : Validated<E, A>) -> Validated<E, A> {
-        return fold(constF(defaultValue), Validated.valid)
+        return fold(constant(defaultValue), Validated.valid)
     }
     
     public func handleLeftWith(_ f : (E) -> Validated<E, A>) -> Validated<E, A> {
@@ -272,7 +272,7 @@ public class ValidatedEq<L, R, EqL, EqR> : Eq where EqL : Eq, EqL.A == L, EqR : 
     public func eqv(_ a: ValidatedOf<L, R>, _ b: ValidatedOf<L, R>) -> Bool {
         let a = Validated.fix(a)
         let b = Validated.fix(b)
-        return a.fold({ aInvalid in b.fold({ bInvalid in eql.eqv(aInvalid, bInvalid)}, constF(false))},
-                      { aValid in b.fold(constF(false), { bValid in eqr.eqv(aValid, bValid) })})
+        return a.fold({ aInvalid in b.fold({ bInvalid in eql.eqv(aInvalid, bInvalid)}, constant(false))},
+                      { aValid in b.fold(constant(false), { bValid in eqr.eqv(aValid, bValid) })})
     }
 }

--- a/Sources/Bow/Instances/BoolInstances.swift
+++ b/Sources/Bow/Instances/BoolInstances.swift
@@ -22,7 +22,7 @@ public class OrSemigroup : Semigroup {
     }
 }
 
-public class OrMonoid : OrSemigroup {
+public class OrMonoid : OrSemigroup, Monoid {
     public var empty : Bool {
         return false
     }

--- a/Sources/Bow/Instances/MaybeInstances.swift
+++ b/Sources/Bow/Instances/MaybeInstances.swift
@@ -11,7 +11,7 @@ public class FirstMaybeMonoid<B> : Monoid {
     }
     
     public func combine(_ a: Const<Maybe<B>, First>, _ b: Const<Maybe<B>, First>) -> Const<Maybe<B>, First> {
-        return a.value.fold(constF(false), constF(true)) ? a : b
+        return a.value.fold(constant(false), constant(true)) ? a : b
     }
 }
 
@@ -23,6 +23,6 @@ public class LastMaybeMonoid<B> : Monoid {
     }
     
     public func combine(_ a: Const<Maybe<B>, Last>, _ b: Const<Maybe<B>, Last>) -> Const<Maybe<B>, Last> {
-        return b.value.fold(constF(false), constF(true)) ? b : a
+        return b.value.fold(constant(false), constant(true)) ? b : a
     }
 }

--- a/Sources/Bow/Optics/Fold.swift
+++ b/Sources/Bow/Optics/Fold.swift
@@ -59,7 +59,7 @@ open class Fold<S, A> : FoldOf<S, A> {
     }
     
     public func size(_ s : S) -> Int {
-        return foldMap(Int.sumMonoid, s, constF(1))
+        return foldMap(Int.sumMonoid, s, constant(1))
     }
     
     public func forAll(_ s : S, _ predicate : @escaping (A) -> Bool) -> Bool {
@@ -67,7 +67,7 @@ open class Fold<S, A> : FoldOf<S, A> {
     }
     
     public func isEmpty(_ s : S) -> Bool {
-        return foldMap(Bool.andMonoid, s, constF(false))
+        return foldMap(Bool.andMonoid, s, constant(false))
     }
     
     public func nonEmpty(_ s : S) -> Bool {
@@ -139,7 +139,7 @@ open class Fold<S, A> : FoldOf<S, A> {
     }
     
     public func exists(_ s : S, _ predicate : @escaping (A) -> Bool) -> Bool {
-        return find(s, predicate).fold(constF(false), constF(true))
+        return find(s, predicate).fold(constant(false), constant(true))
     }
 }
 

--- a/Sources/Bow/Optics/Lens.swift
+++ b/Sources/Bow/Optics/Lens.swift
@@ -51,7 +51,7 @@ public class PLens<S, T, A, B> : PLensOf<S, T, A, B> {
     public static func codiagonal() -> Lens<Either<S, S>, S> {
         return Lens<Either<S, S>, S>(
             get: { ess in ess.fold(id, id) },
-            set: { ess, s in ess.bimap(constF(s), constF(s)) })
+            set: { ess, s in ess.bimap(constant(s), constant(s)) })
     }
     
     public init(get : @escaping (S) -> A, set : @escaping (S, B) -> T) {

--- a/Sources/Bow/Optics/Optional.swift
+++ b/Sources/Bow/Optics/Optional.swift
@@ -50,7 +50,7 @@ public class POptional<S, T, A, B> : POptionalOf<S, T, A, B> {
     
     public static func codiagonal() -> Optional<Either<S, S>, S> {
         return Optional<Either<S, S>, S>(
-            set: { ess, s in ess.bimap(constF(s), constF(s)) },
+            set: { ess, s in ess.bimap(constant(s), constant(s)) },
             getOrModify: { ess in ess.fold(Either.right, Either.right) })
     }
     
@@ -84,7 +84,7 @@ public class POptional<S, T, A, B> : POptionalOf<S, T, A, B> {
     }
     
     public func setMaybe(_ s : S, _ b : B) -> Maybe<T> {
-        return modifyMaybe(s, constF(b))
+        return modifyMaybe(s, constant(b))
     }
     
     public func isEmpty(_ s : S) -> Bool {
@@ -92,7 +92,7 @@ public class POptional<S, T, A, B> : POptionalOf<S, T, A, B> {
     }
     
     public func nonEmpty(_ s : S) -> Bool {
-        return getMaybe(s).fold(constF(false), constF(true))
+        return getMaybe(s).fold(constant(false), constant(true))
     }
     
     public func choice<S1, T1>(_ other : POptional<S1, T1, A, B>) -> POptional<Either<S, S1>, Either<T, T1>, A, B> {
@@ -134,11 +134,11 @@ public class POptional<S, T, A, B> : POptionalOf<S, T, A, B> {
     }
     
     public func exists(_ s : S, _ predicate : @escaping (A) -> Bool) -> Bool {
-        return getMaybe(s).fold(constF(false), predicate)
+        return getMaybe(s).fold(constant(false), predicate)
     }
     
     public func all(_ s : S, _ predicate : @escaping (A) -> Bool) -> Bool {
-        return getMaybe(s).fold(constF(true), predicate)
+        return getMaybe(s).fold(constant(true), predicate)
     }
     
     public func compose<C, D>(_ other : POptional<A, B, C, D>) -> POptional<S, T, C, D> {

--- a/Sources/Bow/Optics/Prism.swift
+++ b/Sources/Bow/Optics/Prism.swift
@@ -76,15 +76,15 @@ public class PPrism<S, T, A, B> : PPrismOf<S, T, A, B> {
     }
     
     public func set(_ s : S, _ b : B) -> T {
-        return modify(s, constF(b))
+        return modify(s, constant(b))
     }
     
     public func setMaybe(_ s : S, _ b : B) -> Maybe<T> {
-        return modifyMaybe(s, constF(b))
+        return modifyMaybe(s, constant(b))
     }
     
     public func nonEmpty(_ s : S) -> Bool {
-        return getMaybe(s).fold(constF(false), constF(true))
+        return getMaybe(s).fold(constant(false), constant(true))
     }
     
     public func isEmpty(_ s : S) -> Bool {
@@ -132,11 +132,11 @@ public class PPrism<S, T, A, B> : PPrismOf<S, T, A, B> {
     }
     
     public func exists(_ s : S, _ predicate : @escaping (A) -> Bool) -> Bool {
-        return getMaybe(s).fold(constF(false), predicate)
+        return getMaybe(s).fold(constant(false), predicate)
     }
     
     public func all(_ s : S, _ predicate : @escaping(A) -> Bool) -> Bool {
-        return getMaybe(s).fold(constF(true), predicate)
+        return getMaybe(s).fold(constant(true), predicate)
     }
     
     public func left<C>() -> PPrism<Either<S, C>, Either<T, C>, Either<A, C>, Either<B, C>> {

--- a/Sources/Bow/Optics/Setter.swift
+++ b/Sources/Bow/Optics/Setter.swift
@@ -56,7 +56,7 @@ public class PSetter<S, T, A, B> : PSetterOf<S, T, A, B> {
     
     public init(modify : @escaping (@escaping (A) -> B) -> (S) -> T) {
         self.modifyFunc = { s, f in modify(f)(s) }
-        self.setFunc = { s, b in modify(constF(b))(s) }
+        self.setFunc = { s, b in modify(constant(b))(s) }
     }
     
     public func modify(_ s : S, _ f : @escaping (A) -> B) -> T {

--- a/Sources/Bow/Optics/Traversal.swift
+++ b/Sources/Bow/Optics/Traversal.swift
@@ -196,15 +196,15 @@ open class PTraversal<S, T, A, B> : PTraversalOf<S, T, A, B> {
     }
     
     public func set(_ s : S, _ b : B) -> T {
-        return modify(s, constF(b))
+        return modify(s, constant(b))
     }
     
     public func size(_ s : S) -> Int {
-        return foldMap(Int.sumMonoid, s, constF(1))
+        return foldMap(Int.sumMonoid, s, constant(1))
     }
     
     public func isEmpty(_ s : S) -> Bool {
-        return foldMap(Bool.andMonoid, s, constF(false))
+        return foldMap(Bool.andMonoid, s, constant(false))
     }
     
     public func nonEmpty(_ s : S) -> Bool {
@@ -270,7 +270,7 @@ open class PTraversal<S, T, A, B> : PTraversalOf<S, T, A, B> {
     }
     
     public func exists(_ s : S, _ predicate : @escaping (A) -> Bool) -> Bool {
-        return find(s, predicate).fold(constF(false), constF(true))
+        return find(s, predicate).fold(constant(false), constant(true))
     }
     
     public func forall(_ s : S, _ predicate : @escaping (A) -> Bool) -> Bool {

--- a/Sources/Bow/Predef.swift
+++ b/Sources/Bow/Predef.swift
@@ -7,23 +7,23 @@ public func id<A>(_ a : A) -> A {
     return a
 }
 
-func constF<A>(_ a : A) -> () -> A {
+func constant<A>(_ a : A) -> () -> A {
     return { a }
 }
 
-func constF<A, B>(_ a : A) -> (B) -> A {
+func constant<A, B>(_ a : A) -> (B) -> A {
     return { _ in a }
 }
 
-func constF<A, B, C>(_ a : A) -> (B, C) -> A {
+func constant<A, B, C>(_ a : A) -> (B, C) -> A {
     return { _, _ in a }
 }
 
-func constF<A, B, C, D>(_ a : A) -> (B, C, D) -> A {
+func constant<A, B, C, D>(_ a : A) -> (B, C, D) -> A {
     return { _, _, _ in a }
 }
 
-func constF<A, B, C, D, E>(_ a : A) -> (B, C, D, E) -> A {
+func constant<A, B, C, D, E>(_ a : A) -> (B, C, D, E) -> A {
     return { _, _, _, _ in a }
 }
 

--- a/Sources/Bow/Transformers/EitherT.swift
+++ b/Sources/Bow/Transformers/EitherT.swift
@@ -96,7 +96,7 @@ public class EitherT<F, A, B> : EitherTOf<F, A, B> {
     
     public func combineK<Mon>(_ y : EitherT<F, A, B>, _ monad : Mon) -> EitherT<F, A, B> where Mon : Monad, Mon.F == F {
         return EitherT<F, A, B>(monad.flatMap(value, { either in
-            either.fold(constF(y.value), { b in monad.pure(Either<A, B>.right(b)) })
+            either.fold(constant(y.value), { b in monad.pure(Either<A, B>.right(b)) })
         }))
     }
 }

--- a/Sources/Bow/Transformers/MaybeT.swift
+++ b/Sources/Bow/Transformers/MaybeT.swift
@@ -74,7 +74,7 @@ public class MaybeT<F, A> : MaybeTOf<F, A> {
     }
     
     public func getOrElseF<Mon>(_ defaultValue : Kind<F, A>, _ monad : Mon) -> Kind<F, A> where Mon : Monad, Mon.F == F {
-        return monad.flatMap(value, { maybe in maybe.fold(constF(defaultValue), monad.pure)})
+        return monad.flatMap(value, { maybe in maybe.fold(constant(defaultValue), monad.pure)})
     }
     
     public func filter<Func>(_ predicate : @escaping (A) -> Bool, _ functor : Func) -> MaybeT<F, A> where Func : Functor, Func.F == F {
@@ -99,7 +99,7 @@ public class MaybeT<F, A> : MaybeTOf<F, A> {
     
     public func orElseF<Mon>(_ defaultValue : Kind<F, Maybe<A>>, _ monad : Mon) -> MaybeT<F, A> where Mon : Monad, Mon.F == F {
         return MaybeT<F, A>(monad.flatMap(value, { maybe in
-            maybe.fold(constF(defaultValue),
+            maybe.fold(constant(defaultValue),
                        { _ in monad.pure(maybe) }) }))
     }
     

--- a/Sources/Bow/Transformers/MaybeT.swift
+++ b/Sources/Bow/Transformers/MaybeT.swift
@@ -111,8 +111,8 @@ public class MaybeT<F, A> : MaybeTOf<F, A> {
         return transform({ maybe in maybe.flatMap(f) }, functor)
     }
     
-    public func mapFilter<B, Func>(_ f : @escaping (A) -> Maybe<B>, _ functor : Func) -> MaybeT<F, B> where Func : Functor, Func.F == F {
-        return MaybeT<F, B>(functor.map(value, { maybe in maybe.flatMap(f) }))
+    public func mapFilter<B, Func>(_ f : @escaping (A) -> MaybeOf<B>, _ functor : Func) -> MaybeT<F, B> where Func : Functor, Func.F == F {
+        return MaybeT<F, B>(functor.map(value, { maybe in maybe.flatMap({ x in f(x).fix() }) }))
     }
 }
 
@@ -162,7 +162,7 @@ public class MaybeTFunctor<G, FuncG> : Functor where FuncG : Functor, FuncG.F ==
 
 public class MaybeTFunctorFilter<G, FuncG> : MaybeTFunctor<G, FuncG>, FunctorFilter where FuncG : Functor, FuncG.F == G {
     
-    public func mapFilter<A, B>(_ fa: MaybeTOf<G, A>, _ f: @escaping (A) -> Maybe<B>) -> MaybeTOf<G, B> {
+    public func mapFilter<A, B>(_ fa: MaybeTOf<G, A>, _ f: @escaping (A) -> MaybeOf<B>) -> MaybeTOf<G, B> {
         return MaybeT.fix(fa).mapFilter(f, functor)
     }
 }

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -217,7 +217,7 @@ public class WriterTMonad<G, W, MonG, MonoW> : WriterTApplicative<G, W, MonG, Mo
 }
 
 public class WriterTMonadFilter<G, W, MonFilG, MonoW> : WriterTMonad<G, W, MonFilG, MonoW>, MonadFilter where MonFilG : MonadFilter, MonFilG.F == G, MonoW : Monoid, MonoW.A == W {
-    
+
     private let monadFilter : MonFilG
     
     override public init(_ monadFilter : MonFilG, _ monoid : MonoW) {

--- a/Sources/Bow/Transformers/WriterT.swift
+++ b/Sources/Bow/Transformers/WriterT.swift
@@ -133,7 +133,7 @@ public class WriterT<F, W, A> : WriterTOf<F, W, A> {
     }
     
     public func reset<Mono, Mon>(_ monoid : Mono, _ monad : Mon) -> WriterT<F, W, A> where Mono : Monoid, Mono.A == W, Mon : Monad, Mon.F == F {
-        return mapAcc(constF(monoid.empty), monad)
+        return mapAcc(constant(monoid.empty), monad)
     }
 }
 

--- a/Sources/Bow/Typeclasses/Foldable.swift
+++ b/Sources/Bow/Typeclasses/Foldable.swift
@@ -14,7 +14,7 @@ public extension Foldable {
     
     public func reduceLeftToMaybe<A, B>(_ fa : Kind<F, A>, _ f : @escaping (A) -> B, _ g : @escaping(B, A) -> B) -> Maybe<B> {
         return foldL(fa, Maybe.empty(), { maybe, a in
-            maybe.fold(constF(Maybe<B>.some(f(a))),
+            maybe.fold(constant(Maybe<B>.some(f(a))),
                        { b in Maybe<B>.some(g(b, a)) })
         })
     }
@@ -92,7 +92,7 @@ public extension Foldable {
         return (foldM(fa, Int64(0), { i, a in
             (i == index) ? Either<A, Int64>.left(a) : Either<A, Int64>.right(i + 1)
         }, Either<A, Int64>.monad() as EitherMonad<A>) as! Either<A, Int64>)
-            .fold(Maybe<A>.some, constF(Maybe<A>.none()))
+            .fold(Maybe<A>.some, constant(Maybe<A>.none()))
     }
     
     public func size<A, Mono>(_ monoid : Mono, _ fa : Kind<F, A>) -> Int64 where Mono : Monoid, Mono.A == Int64 {

--- a/Sources/Bow/Typeclasses/FunctorFilter.swift
+++ b/Sources/Bow/Typeclasses/FunctorFilter.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 public protocol FunctorFilter : Functor {
-    func mapFilter<A, B>(_ fa : Kind<F, A>, _ f : @escaping (A) -> Maybe<B>) -> Kind<F, B>
+    func mapFilter<A, B>(_ fa : Kind<F, A>, _ f : @escaping (A) -> MaybeOf<B>) -> Kind<F, B>
 }
 
 public extension FunctorFilter {
-    public func flattenOption<A>(_ fa : Kind<F, Maybe<A>>) -> Kind<F, A> {
+    public func flattenOption<A>(_ fa : Kind<F, MaybeOf<A>>) -> Kind<F, A> {
         return self.mapFilter(fa, id)
     }
     

--- a/Sources/Bow/Typeclasses/Monad.swift
+++ b/Sources/Bow/Typeclasses/Monad.swift
@@ -27,7 +27,7 @@ public extension Monad {
     }
     
     public func forEffectEval<A, B>(_ fa : Kind<F, A>, _ fb : Eval<Kind<F, B>>) -> Kind<F, A> {
-        return self.flatMap(fa, { a in self.map(fb.value(), constF(a)) })
+        return self.flatMap(fa, { a in self.map(fb.value(), constant(a)) })
     }
     
     public func mproduct<A, B>(_ fa : Kind<F, A>, _ f : @escaping (A) -> Kind<F, B>) -> Kind<F, (A, B)> {

--- a/Sources/Bow/Typeclasses/MonadCombine.swift
+++ b/Sources/Bow/Typeclasses/MonadCombine.swift
@@ -8,8 +8,8 @@ public extension MonadCombine {
     }
     
     public func separate<G, A, B, Bifold>(_ fgab : Kind<F, Kind2<G, A, B>>, _ bifoldable : Bifold) -> (Kind<F, A>, Kind<F, B>) where Bifold : Bifoldable, Bifold.F == G {
-        let asep = flatMap(fgab, { gab in bifoldable.bifoldMap(gab, self.pure, constF(self.empty()), self.algebra()) })
-        let bsep = flatMap(fgab, { gab in bifoldable.bifoldMap(gab, constF(self.empty()), self.pure, self.algebra()) } )
+        let asep = flatMap(fgab, { gab in bifoldable.bifoldMap(gab, self.pure, constant(self.empty()), self.algebra()) })
+        let bsep = flatMap(fgab, { gab in bifoldable.bifoldMap(gab, constant(self.empty()), self.pure, self.algebra()) } )
         return (asep, bsep)
     }
 }

--- a/Sources/Bow/Typeclasses/MonadFilter.swift
+++ b/Sources/Bow/Typeclasses/MonadFilter.swift
@@ -5,9 +5,9 @@ public protocol MonadFilter : Monad, FunctorFilter {
 }
 
 public extension MonadFilter {
-    public func mapFilter<A, B>(_ fa : Kind<F, A>, _ f : @escaping (A) -> Maybe<B>) -> Kind<F, B>{
+    public func mapFilter<A, B>(_ fa : Kind<F, A>, _ f : @escaping (A) -> MaybeOf<B>) -> Kind<F, B>{
         return flatMap(fa, { a in
-            f(a).fold(self.empty, self.pure)
+            f(a).fix().fold(self.empty, self.pure)
         })
     }
 }

--- a/Sources/Bow/Typeclasses/TraverseFilter.swift
+++ b/Sources/Bow/Typeclasses/TraverseFilter.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 public protocol TraverseFilter : Traverse, FunctorFilter {
-    func traverseFilter<A, B, G, Appl>(_ fa : Kind<F, A>, _ f : @escaping (A) -> Kind<G, Maybe<B>>, _ applicative : Appl) -> Kind<G, Kind<F, B>> where Appl : Applicative, Appl.F == G
+    func traverseFilter<A, B, G, Appl>(_ fa : Kind<F, A>, _ f : @escaping (A) -> Kind<G, MaybeOf<B>>, _ applicative : Appl) -> Kind<G, Kind<F, B>> where Appl : Applicative, Appl.F == G
 }
 
 public extension TraverseFilter {
-    public func mapFilter<A, B>(_ fa: Kind<F, A>, _ f: @escaping (A) -> Maybe<B>) -> Kind<F, B> {
-        return (traverseFilter(fa, { a in Id<Maybe<B>>.pure(f(a)) }, Id<Maybe<B>>.applicative()) as! Id<Kind<F, B>>).extract()
+    public func mapFilter<A, B>(_ fa: Kind<F, A>, _ f: @escaping (A) -> MaybeOf<B>) -> Kind<F, B> {
+        return (traverseFilter(fa, { a in Id<MaybeOf<B>>.pure(f(a)) }, Id<Maybe<B>>.applicative()) as! Id<Kind<F, B>>).extract()
     }
     
     public func filterA<A, G, Appl>(_ fa : Kind<F, A>, _ f : @escaping (A) -> Kind<G, Bool>, _ applicative : Appl) -> Kind<G, Kind<F, A>> where Appl : Applicative, Appl.F == G {

--- a/Tests/BowTests/Arrow/Function0Test.swift
+++ b/Tests/BowTests/Arrow/Function0Test.swift
@@ -31,7 +31,6 @@ class Function0Test: XCTestCase {
     }
     
     func testBimonadLaws() {
-        MonadLaws<ForFunction0>.check(monad: Function0<Int>.bimonad(), eq: self.eq)
-        ComonadLaws<ForFunction0>.check(comonad: Function0<Int>.bimonad(), generator: self.generator, eq: self.eq)
+        BimonadLaws<ForFunction0>.check(bimonad: Function0<Int>.bimonad(), generator: self.generator, eq: self.eq)
     }
 }

--- a/Tests/BowTests/Arrow/Function0Test.swift
+++ b/Tests/BowTests/Arrow/Function0Test.swift
@@ -29,4 +29,9 @@ class Function0Test: XCTestCase {
     func testComonadLaws() {
         ComonadLaws<ForFunction0>.check(comonad: Function0<Int>.comonad(), generator: self.generator, eq: self.eq)
     }
+    
+    func testBimonadLaws() {
+        MonadLaws<ForFunction0>.check(monad: Function0<Int>.bimonad(), eq: self.eq)
+        ComonadLaws<ForFunction0>.check(comonad: Function0<Int>.bimonad(), generator: self.generator, eq: self.eq)
+    }
 }

--- a/Tests/BowTests/Data/ConstTest.swift
+++ b/Tests/BowTests/Data/ConstTest.swift
@@ -3,7 +3,7 @@ import SwiftCheck
 @testable import Bow
 
 class ConstTest: XCTestCase {
-    var generator : (Int) -> ConstOf<Int, Int> {
+    var generator : (Int) -> Const<Int, Int> {
         return { a in Const<Int, Int>.pure(a) }
     }
     
@@ -43,6 +43,10 @@ class ConstTest: XCTestCase {
     }
     
     func testShowLaws() {
-        ShowLaws.check(show: Const.show(), generator: { a in Const<Int, Int>.pure(a) })
+        ShowLaws.check(show: Const.show(), generator: self.generator)
+    }
+    
+    func testFoldableLaws() {
+        FoldableLaws<ConstPartial<Int>>.check(foldable: Const<Int, Int>.foldable(), generator: self.generator)
     }
 }

--- a/Tests/BowTests/Data/ConstTest.swift
+++ b/Tests/BowTests/Data/ConstTest.swift
@@ -49,4 +49,8 @@ class ConstTest: XCTestCase {
     func testFoldableLaws() {
         FoldableLaws<ConstPartial<Int>>.check(foldable: Const<Int, Int>.foldable(), generator: self.generator)
     }
+    
+    func testTraverseLaws() {
+        TraverseLaws<ConstPartial<Int>>.check(traverse: Const<Int, Int>.traverse(), functor: Const<Int, Int>.traverse(), generator: self.generator, eq: self.eq)
+    }
 }

--- a/Tests/BowTests/Data/CoproductTest.swift
+++ b/Tests/BowTests/Data/CoproductTest.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class CoproductTest: XCTestCase {
     
-    var generator : (Int) -> CoproductOf<ForId, ForId, Int> {
+    var generator : (Int) -> Coproduct<ForId, ForId, Int> {
         return { a in Coproduct<ForId, ForId, Int>(Either.pure(Id.pure(a))) }
     }
     
@@ -20,5 +20,9 @@ class CoproductTest: XCTestCase {
     
     func testComonadLaws() {
         ComonadLaws<CoproductPartial<ForId, ForId>>.check(comonad: Coproduct<ForId, ForId, Int>.comonad(Id<Int>.comonad(), Id<Int>.comonad()), generator: self.generator, eq: self.eq)
+    }
+    
+    func testFoldableLaws() {
+        FoldableLaws<CoproductPartial<ForId, ForId>>.check(foldable: Coproduct<ForId, ForId, Int>.foldable(Id<Int>.foldable(), Id<Int>.foldable()), generator: self.generator)
     }
 }

--- a/Tests/BowTests/Data/CoproductTest.swift
+++ b/Tests/BowTests/Data/CoproductTest.swift
@@ -25,4 +25,12 @@ class CoproductTest: XCTestCase {
     func testFoldableLaws() {
         FoldableLaws<CoproductPartial<ForId, ForId>>.check(foldable: Coproduct<ForId, ForId, Int>.foldable(Id<Int>.foldable(), Id<Int>.foldable()), generator: self.generator)
     }
+    
+    func testTraverseLaws() {
+        TraverseLaws<CoproductPartial<ForId, ForId>>.check(
+            traverse: Coproduct<ForId, ForId, Int>.traverse(Id<Int>.traverse(), Id<Int>.traverse()),
+            functor: Coproduct<ForId, ForId, Int>.functor(Id<Int>.functor(), Id<Int>.functor()),
+            generator: self.generator,
+            eq: self.eq)
+    }
 }

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -47,6 +47,11 @@ class EitherTest: XCTestCase {
         ShowLaws.check(show: Either.show(), generator: { a in (a % 2 == 0) ? Either<Int, Int>.pure(a) : Either<Int, Int>.left(a) })
     }
     
+    func testFoldableLaws() {
+        FoldableLaws<EitherPartial<Int>>.check(foldable: Either<Int, Int>.foldable(),
+                                               generator: self.generator)
+    }
+    
     func testCheckers() {
         let left = Either<String, Int>.left("Hello")
         let right = Either<String, Int>.right(5)

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Nimble
+import SwiftCheck
 @testable import Bow
 
 class EitherTest: XCTestCase {
@@ -41,6 +42,12 @@ class EitherTest: XCTestCase {
     
     func testSemigroupKLaws() {
         SemigroupKLaws<EitherPartial<Int>>.check(semigroupK: Either<Int, Int>.semigroupK(), generator: self.generator, eq: self.eq)
+    }
+    
+    func testSemigroupLaws() {
+        property("Sum semigroup laws") <- forAll { (a : Int, b : Int, c : Int) in
+            return SemigroupLaws.check(semigroup: Either<Int, Int>.semigroupK().algebra(), a: Either.right(a), b: Either.right(b), c: Either.right(c), eq: self.eq)
+        }
     }
     
     func testShowLaws() {

--- a/Tests/BowTests/Data/EitherTest.swift
+++ b/Tests/BowTests/Data/EitherTest.swift
@@ -59,6 +59,13 @@ class EitherTest: XCTestCase {
                                                generator: self.generator)
     }
     
+    func testTraverseLaws() {
+        TraverseLaws<EitherPartial<Int>>.check(traverse: Either<Int, Int>.traverse(),
+                                               functor: Either<Int, Int>.functor(),
+                                               generator: self.generator,
+                                               eq: self.eq)
+    }
+    
     func testCheckers() {
         let left = Either<String, Int>.left("Hello")
         let right = Either<String, Int>.right(5)

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -3,7 +3,7 @@ import SwiftCheck
 @testable import Bow
 
 class IdTest: XCTestCase {
-    var generator : (Int) -> IdOf<Int> {
+    var generator : (Int) -> Id<Int> {
         return { a in Id<Int>.pure(a) }
     }
     
@@ -31,6 +31,10 @@ class IdTest: XCTestCase {
     }
     
     func testShowLaws() {
-        ShowLaws.check(show: Id.show(), generator: { a in Id.pure(a) })
+        ShowLaws.check(show: Id.show(), generator: self.generator)
+    }
+    
+    func testFoldableLaws() {
+        FoldableLaws<ForId>.check(foldable: Id<Int>.foldable(), generator: self.generator)
     }
 }

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -37,4 +37,8 @@ class IdTest: XCTestCase {
     func testFoldableLaws() {
         FoldableLaws<ForId>.check(foldable: Id<Int>.foldable(), generator: self.generator)
     }
+    
+    func testBimonadLaws() {
+        
+    }
 }

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -41,4 +41,8 @@ class IdTest: XCTestCase {
     func testBimonadLaws() {
         BimonadLaws<ForId>.check(bimonad: Id<Int>.bimonad(), generator: self.generator, eq: self.eq)
     }
+    
+    func testTraverseLaws() {
+        TraverseLaws<ForId>.check(traverse: Id<Int>.traverse(), functor: Id<Int>.functor(), generator: self.generator, eq: self.eq)
+    }
 }

--- a/Tests/BowTests/Data/IdTest.swift
+++ b/Tests/BowTests/Data/IdTest.swift
@@ -39,6 +39,6 @@ class IdTest: XCTestCase {
     }
     
     func testBimonadLaws() {
-        
+        BimonadLaws<ForId>.check(bimonad: Id<Int>.bimonad(), generator: self.generator, eq: self.eq)
     }
 }

--- a/Tests/BowTests/Data/IorTest.swift
+++ b/Tests/BowTests/Data/IorTest.swift
@@ -2,8 +2,12 @@ import XCTest
 @testable import Bow
 
 class IorTest: XCTestCase {
-    var generator : (Int) -> IorOf<Int, Int> {
-        return { a in Ior<Int, Int>.right(a) }
+    var generator = { (a : Int) -> Ior<Int, Int> in
+        switch a % 3 {
+        case 0 : return Ior.left(a)
+        case 1: return Ior.right(a)
+        default: return Ior.both(a, a)
+        }
     }
     
     let eq = Ior.eq(Int.order, Int.order)
@@ -26,12 +30,10 @@ class IorTest: XCTestCase {
     }
     
     func testShowLaws() {
-        ShowLaws.check(show: Ior.show(), generator: { (a : Int) -> Ior<Int, Int> in
-            switch a % 3 {
-            case 0 : return Ior.left(a)
-            case 1: return Ior.right(a)
-            default: return Ior.both(a, a)
-            }
-        })
+        ShowLaws.check(show: Ior.show(), generator: self.generator)
+    }
+    
+    func testFoldableLaws() {
+        FoldableLaws<IorPartial<Int>>.check(foldable: Ior<Int, Int>.foldable(), generator: self.generator)
     }
 }

--- a/Tests/BowTests/Data/ListKTest.swift
+++ b/Tests/BowTests/Data/ListKTest.swift
@@ -36,6 +36,15 @@ class ListKTest: XCTestCase {
                 c: ListK<Int>.pure(c),
                 eq: self.eq)
         }
+        
+        property("ListK semigroupK algebra semigroup laws") <- forAll() { (a : Int, b : Int, c : Int) in
+            return SemigroupLaws.check(
+                semigroup: ListK<Int>.semigroupK().algebra(),
+                a: ListK<Int>.pure(a),
+                b: ListK<Int>.pure(b),
+                c: ListK<Int>.pure(c),
+                eq: self.eq)
+        }
     }
     
     func testSemigroupKLaws() {

--- a/Tests/BowTests/Data/ListKTest.swift
+++ b/Tests/BowTests/Data/ListKTest.swift
@@ -55,6 +55,10 @@ class ListKTest: XCTestCase {
         property("ListK monoid laws") <- forAll() { (a : Int) in
             return MonoidLaws<ListKOf<Int>>.check(monoid: ListK<Int>.monoid(), a: ListK<Int>.pure(a), eq: self.eq)
         }
+        
+        property("ListK monoidK algebra monoid laws") <- forAll() { (a : Int) in
+            return MonoidLaws<ListKOf<Int>>.check(monoid: ListK<Int>.monoidK().algebra(), a: ListK<Int>.pure(a), eq: self.eq)
+        }
     }
     
     func testMonoidKLaws() {

--- a/Tests/BowTests/Data/ListKTest.swift
+++ b/Tests/BowTests/Data/ListKTest.swift
@@ -72,4 +72,8 @@ class ListKTest: XCTestCase {
     func testFoldableLaws() {
         FoldableLaws<ForListK>.check(foldable: ListK<Int>.foldable(), generator: self.generator)
     }
+    
+    func testMonadCombineLaws() {
+        MonadCombineLaws<ForListK>.check(monadCombine: ListK<Int>.monadCombine(), eq: self.eq)
+    }
 }

--- a/Tests/BowTests/Data/ListKTest.swift
+++ b/Tests/BowTests/Data/ListKTest.swift
@@ -59,4 +59,8 @@ class ListKTest: XCTestCase {
     func testMonadFilterLaws() {
         MonadFilterLaws<ForListK>.check(monadFilter: ListK<Int>.monadFilter(), generator: self.generator, eq: self.eq)
     }
+    
+    func testFoldableLaws() {
+        FoldableLaws<ForListK>.check(foldable: ListK<Int>.foldable(), generator: self.generator)
+    }
 }

--- a/Tests/BowTests/Data/ListKTest.swift
+++ b/Tests/BowTests/Data/ListKTest.swift
@@ -80,4 +80,11 @@ class ListKTest: XCTestCase {
     func testMonadCombineLaws() {
         MonadCombineLaws<ForListK>.check(monadCombine: ListK<Int>.monadCombine(), eq: self.eq)
     }
+    
+    func testTraverseLaws() {
+        TraverseLaws<ForListK>.check(traverse: ListK<Int>.traverse(),
+                                     functor: ListK<Int>.functor(),
+                                     generator: self.generator,
+                                     eq: self.eq)
+    }
 }

--- a/Tests/BowTests/Data/MaybeTest.swift
+++ b/Tests/BowTests/Data/MaybeTest.swift
@@ -83,6 +83,10 @@ class MaybeTest: XCTestCase {
         TraverseLaws<ForMaybe>.check(traverse: Maybe<Int>.traverse(), functor: Maybe<Int>.functor(), generator: self.generator, eq: self.eq)
     }
     
+    func testTraverseFilterLaws() {
+        TraverseFilterLaws<ForMaybe>.check(traverseFilter: Maybe<Int>.traverseFilter(), applicative: Maybe<Int>.applicative(), eq: Maybe.eq(self.eq))
+    }
+    
     func testFromToOption() {
         property("fromOption - toOption isomorphism") <- forAll { (x : Int?, y : Int) in
             let maybe = y % 2 == 0 ? Maybe<Int>.none() : Maybe<Int>.some(y)

--- a/Tests/BowTests/Data/MaybeTest.swift
+++ b/Tests/BowTests/Data/MaybeTest.swift
@@ -86,4 +86,35 @@ class MaybeTest: XCTestCase {
                 Maybe.eq(Int.order).eqv(Maybe.fromOption(maybe.toOption()), maybe)
         }
     }
+    
+    func testDefinedOrEmpty() {
+        property("Maybe cannot be simultaneously empty and defined") <- forAll { (x : Int?) in
+            let maybe = Maybe.fromOption(x)
+            return xor(maybe.isEmpty, maybe.isDefined)
+        }
+    }
+    
+    func testGetOrElse() {
+        property("getOrElse consistent with orElse") <- forAll { (x : Int?, y : Int) in
+            let maybe = Maybe.fromOption(x)
+            return Maybe.eq(Int.order).eqv(Maybe<Int>.pure(maybe.getOrElse(y)),
+                                           maybe.orElse(Maybe.pure(y)))
+        }
+    }
+    
+    func testFilter() {
+        property("filter is opposite of filterNot") <- forAll { (x : Int?, predicate : ArrowOf<Int, Bool>) in
+            let maybe = Maybe.fromOption(x)
+            let eq = Maybe.eq(Int.order)
+            let none = Maybe<Int>.none()
+            return xor(eq.eqv(maybe.filter(predicate.getArrow), none), eq.eqv(maybe.filterNot(predicate.getArrow), none))
+        }
+    }
+    
+    func testExistForAll() {
+        property("exists and forall are equivalent") <- forAll { (x : Int?, predicate : ArrowOf<Int, Bool>) in
+            let maybe = Maybe.fromOption(x)
+            return maybe.exists(predicate.getArrow) == maybe.forall(predicate.getArrow)
+        }
+    }
 }

--- a/Tests/BowTests/Data/MaybeTest.swift
+++ b/Tests/BowTests/Data/MaybeTest.swift
@@ -12,8 +12,8 @@ class UnitEq : Eq {
 
 class MaybeTest: XCTestCase {
     
-    var generator : (Int) -> MaybeOf<Int> {
-        return { a in Maybe.pure(a) }
+    var generator : (Int) -> Maybe<Int> {
+        return { a in a % 2 == 0 ? Maybe.pure(a) : Maybe.none() }
     }
     
     let eq = Maybe.eq(Int.order)
@@ -72,6 +72,18 @@ class MaybeTest: XCTestCase {
     }
     
     func testShowLaws() {
-        ShowLaws.check(show: Maybe.show(), generator: { a in (a % 2 == 0) ? Maybe.some(a) : Maybe.none() })
+        ShowLaws.check(show: Maybe.show(), generator: self.generator)
+    }
+    
+    func testFoldableLaws() {
+        FoldableLaws<ForMaybe>.check(foldable: Maybe<Int>.foldable(), generator: self.generator)
+    }
+    
+    func testFromToOption() {
+        property("fromOption - toOption isomorphism") <- forAll { (x : Int?, y : Int) in
+            let maybe = y % 2 == 0 ? Maybe<Int>.none() : Maybe<Int>.some(y)
+            return Maybe.fromOption(x).toOption() == x &&
+                Maybe.eq(Int.order).eqv(Maybe.fromOption(maybe.toOption()), maybe)
+        }
     }
 }

--- a/Tests/BowTests/Data/MaybeTest.swift
+++ b/Tests/BowTests/Data/MaybeTest.swift
@@ -79,6 +79,10 @@ class MaybeTest: XCTestCase {
         FoldableLaws<ForMaybe>.check(foldable: Maybe<Int>.foldable(), generator: self.generator)
     }
     
+    func testTraverseLaws() {
+        TraverseLaws<ForMaybe>.check(traverse: Maybe<Int>.traverse(), functor: Maybe<Int>.functor(), generator: self.generator, eq: self.eq)
+    }
+    
     func testFromToOption() {
         property("fromOption - toOption isomorphism") <- forAll { (x : Int?, y : Int) in
             let maybe = y % 2 == 0 ? Maybe<Int>.none() : Maybe<Int>.some(y)

--- a/Tests/BowTests/Data/NonEmptyListTest.swift
+++ b/Tests/BowTests/Data/NonEmptyListTest.swift
@@ -44,6 +44,15 @@ class NonEmptyListTest: XCTestCase {
                     c: NonEmptyList<Int>.pure(c),
                     eq: self.eq)
         }
+        
+        property("NonEmptyList semigroup laws") <- forAll { (a : Int, b : Int, c : Int) in
+            return SemigroupLaws<NonEmptyListOf<Int>>.check(
+                semigroup: NonEmptyList<Int>.semigroupK().algebra(),
+                a: NonEmptyList<Int>.pure(a),
+                b: NonEmptyList<Int>.pure(b),
+                c: NonEmptyList<Int>.pure(c),
+                eq: self.eq)
+        }
     }
     
     func testSemigroupKLaws() {

--- a/Tests/BowTests/Data/NonEmptyListTest.swift
+++ b/Tests/BowTests/Data/NonEmptyListTest.swift
@@ -31,6 +31,10 @@ class NonEmptyListTest: XCTestCase {
         ComonadLaws<ForNonEmptyList>.check(comonad: NonEmptyList<Int>.comonad(), generator: self.generator, eq: self.eq)
     }
     
+    func testBimonadLaws() {
+        BimonadLaws<ForNonEmptyList>.check(bimonad: NonEmptyList<Int>.bimonad(), generator: self.generator, eq: self.eq)
+    }
+    
     func testSemigroupLaws() {
         property("NonEmptyList semigroup laws") <- forAll { (a : Int, b : Int, c : Int) in
             return SemigroupLaws<NonEmptyListOf<Int>>.check(

--- a/Tests/BowTests/Data/NonEmptyListTest.swift
+++ b/Tests/BowTests/Data/NonEmptyListTest.swift
@@ -57,4 +57,28 @@ class NonEmptyListTest: XCTestCase {
     func testFoldableLaws() {
         FoldableLaws<ForNonEmptyList>.check(foldable: NonEmptyList<Int>.foldable(), generator: self.generator)
     }
+    
+    private let nelGenerator = ArrayOf<Int>.arbitrary.suchThat { array in array.getArray.count > 0 }
+    
+    func testConcatenation() {
+        property("The length of the concatenation is equal to the sum of lenghts") <- forAll(self.nelGenerator, self.nelGenerator) { (x : ArrayOf<Int>, y : ArrayOf<Int>) in
+            let a = NonEmptyList.fromArrayUnsafe(x.getArray)
+            let b = NonEmptyList.fromArrayUnsafe(y.getArray)
+            return a.count + b.count == (a + b).count
+        }
+        
+        property("Adding one element increases length in one") <- forAll(self.nelGenerator, Int.arbitrary) { (array : ArrayOf<Int>, element : Int) in
+            let nel = NonEmptyList.fromArrayUnsafe(array.getArray)
+            return (nel + element).count == nel.count + 1
+        }
+        
+        property("Result of concatenation contains all items from the original lists") <- forAll(self.nelGenerator, self.nelGenerator) {
+            (x : ArrayOf<Int>, y : ArrayOf<Int>) in
+            let a = NonEmptyList.fromArrayUnsafe(x.getArray)
+            let b = NonEmptyList.fromArrayUnsafe(y.getArray)
+            let concatenation = a + b
+            return concatenation.containsAll(elements: a.all()) &&
+                    concatenation.containsAll(elements: b.all())
+        }
+    }
 }

--- a/Tests/BowTests/Data/NonEmptyListTest.swift
+++ b/Tests/BowTests/Data/NonEmptyListTest.swift
@@ -35,6 +35,10 @@ class NonEmptyListTest: XCTestCase {
         BimonadLaws<ForNonEmptyList>.check(bimonad: NonEmptyList<Int>.bimonad(), generator: self.generator, eq: self.eq)
     }
     
+    func testTraverseLaws() {
+        TraverseLaws<ForNonEmptyList>.check(traverse: NonEmptyList<Int>.traverse(), functor: NonEmptyList<Int>.functor(), generator: self.generator, eq: self.eq)
+    }
+    
     func testSemigroupLaws() {
         property("NonEmptyList semigroup laws") <- forAll { (a : Int, b : Int, c : Int) in
             return SemigroupLaws<NonEmptyListOf<Int>>.check(

--- a/Tests/BowTests/Data/NonEmptyListTest.swift
+++ b/Tests/BowTests/Data/NonEmptyListTest.swift
@@ -4,7 +4,7 @@ import SwiftCheck
 
 class NonEmptyListTest: XCTestCase {
     
-    var generator : (Int) -> NonEmptyListOf<Int> {
+    var generator : (Int) -> NonEmptyList<Int> {
         return { a in NonEmptyList.pure(a) }
     }
     
@@ -47,6 +47,10 @@ class NonEmptyListTest: XCTestCase {
     }
     
     func testShowLaws() {
-        ShowLaws.check(show: NonEmptyList.show(), generator: { a in NonEmptyList(head: a, tail: [a, a])})
+        ShowLaws.check(show: NonEmptyList.show(), generator: self.generator)
+    }
+    
+    func testFoldableLaws() {
+        FoldableLaws<ForNonEmptyList>.check(foldable: NonEmptyList<Int>.foldable(), generator: self.generator)
     }
 }

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -3,8 +3,8 @@ import XCTest
 
 class TryTest: XCTestCase {
     
-    var generator : (Int) -> TryOf<Int> {
-        return { a in Try.pure(a) }
+    var generator : (Int) -> Try<Int> {
+        return { a in (a % 2 == 0) ? Try.invoke(constant(a)) : Try.invoke({ throw TryError.illegalState }) }
     }
     
     let eq = Try.eq(Int.order)
@@ -35,6 +35,10 @@ class TryTest: XCTestCase {
     }
     
     func testShowLaws() {
-        ShowLaws.check(show: Try.show(), generator: { a in (a % 2 == 0) ? Try.success(a) : Try.failure(TryError.illegalState) })
+        ShowLaws.check(show: Try.show(), generator: self.generator)
+    }
+    
+    func testFoldableLaws() {
+        FoldableLaws<ForTry>.check(foldable: Try<Int>.foldable(), generator: self.generator)
     }
 }

--- a/Tests/BowTests/Data/TryTest.swift
+++ b/Tests/BowTests/Data/TryTest.swift
@@ -41,4 +41,8 @@ class TryTest: XCTestCase {
     func testFoldableLaws() {
         FoldableLaws<ForTry>.check(foldable: Try<Int>.foldable(), generator: self.generator)
     }
+    
+    func testTraverseLaws() {
+        TraverseLaws<ForTry>.check(traverse: Try<Int>.traverse(), functor: Try<Int>.functor(), generator: self.generator, eq: self.eq)
+    }
 }

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -5,7 +5,7 @@ import SwiftCheck
 class ValidatedTest: XCTestCase {
     
     var generator : (Int) -> Validated<Int, Int> {
-        return { a in (a % 2 == 0) ? Validated.valid(a) : Validated.invalid(a) }
+        return { a in (a % 2 == 0) ? Validated.pure(a) : Validated.invalid(a) }
     }
     
     let eq = Validated.eq(Int.order, Int.order)
@@ -44,5 +44,57 @@ class ValidatedTest: XCTestCase {
     
     func testFoldableLaws() {
         FoldableLaws<ValidatedPartial<Int>>.check(foldable: Validated<Int, Int>.foldable(), generator: self.generator)
+    }
+    
+    func testApplicativeErrorLaws() {
+        ApplicativeErrorLaws<ValidatedPartial<CategoryError>, CategoryError>.check(
+            applicativeError: Validated<CategoryError, Int>.applicativeError(CategoryError.semigroup),
+            eq: Validated.eq(CategoryError.eq, Int.order),
+            eqEither: Validated.eq(CategoryError.eq, Either.eq(CategoryError.eq, Int.order)),
+            gen: { CategoryError.common })
+    }
+    
+    func testCheckers() {
+        property("valid and invalid are mutually exclusive") <- forAll { (x : Int) in
+            let input = self.generator(x)
+            return xor(input.isValid, input.isInvalid)
+        }
+    }
+    
+    func testConversionConsistency() {
+        property("Consistency fromMaybe - toMaybe") <- forAll { (x : Int?, none : String) in
+            let maybe = Maybe<Int>.fromOption(x)
+            let validated = Validated.fromMaybe(maybe, ifNone: constant(none))
+            return Maybe<Int>.eq(Int.order).eqv(validated.toMaybe(), maybe)
+        }
+        
+        property("Consistency fromEither - toEither") <- forAll { (x : Int) in
+            let either = x % 2 == 0 ? Either.left(x) : Either.right(x)
+            let validated = Validated.fromEither(either)
+            return Either<Int, Int>.eq(Int.order, Int.order).eqv(validated.toEither(), either)
+        }
+        
+        property("Consistency fromTry - toList") <- forAll { (x : Int) in
+            let attempt = x % 2 == 0 ? Try.success(x) : Try.failure(TryError.illegalState)
+            let validated = Validated<TryError, Int>.fromTry(attempt)
+            return (validated.isValid && validated.toList() == [x]) ||
+                    (validated.isInvalid && validated.toList() == [])
+        }
+    }
+    
+    func testBimapEquivalence() {
+        property("bimap is equivalent to map and leftMap") <- forAll { (x : Int, f : ArrowOf<Int, Int>, g : ArrowOf<Int, Int>) in
+            let input = self.generator(x)
+            return self.eq.eqv(input.bimap(f.getArrow, g.getArrow),
+                               input.map(g.getArrow).leftMap(f.getArrow))
+        }
+    }
+    
+    func testSwapIsomorphism() {
+        property("swap twice is equivalent to id") <- forAll { (x : Int) in
+            let input = self.generator(x)
+            return self.eq.eqv(input.swap().swap(),
+                               input)
+        }
     }
 }

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -54,6 +54,10 @@ class ValidatedTest: XCTestCase {
             gen: { CategoryError.common })
     }
     
+    func testTraverseLaws() {
+        TraverseLaws<ValidatedPartial<Int>>.check(traverse: Validated<Int, Int>.traverse(), functor: Validated<Int, Int>.functor(), generator: self.generator, eq: self.eq)
+    }
+    
     func testCheckers() {
         property("valid and invalid are mutually exclusive") <- forAll { (x : Int) in
             let input = self.generator(x)

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SwiftCheck
 @testable import Bow
 
 class ValidatedTest: XCTestCase {
@@ -24,6 +25,17 @@ class ValidatedTest: XCTestCase {
     
     func testSemigroupKLaws() {
         SemigroupKLaws<ValidatedPartial<Int>>.check(semigroupK: Validated<Int, Int>.semigroupK(Int.sumMonoid), generator: self.generator, eq: self.eq)
+    }
+    
+    func testSemigroupLaws() {
+        property("Validated semigroupK algebra semigroup laws") <- forAll { (a : Int, b : Int, c : Int) in
+            return SemigroupLaws.check(
+                semigroup: Validated<Int, Int>.semigroupK(Int.sumMonoid).algebra(),
+                a: Validated.valid(a),
+                b: Validated.valid(b),
+                c: Validated.valid(c),
+                eq: self.eq)
+        }
     }
     
     func testShowLaws() {

--- a/Tests/BowTests/Data/ValidatedTest.swift
+++ b/Tests/BowTests/Data/ValidatedTest.swift
@@ -3,8 +3,8 @@ import XCTest
 
 class ValidatedTest: XCTestCase {
     
-    var generator : (Int) -> ValidatedOf<Int, Int> {
-        return { a in Validated<Int, Int>.pure(a) }
+    var generator : (Int) -> Validated<Int, Int> {
+        return { a in (a % 2 == 0) ? Validated.valid(a) : Validated.invalid(a) }
     }
     
     let eq = Validated.eq(Int.order, Int.order)
@@ -27,6 +27,10 @@ class ValidatedTest: XCTestCase {
     }
     
     func testShowLaws() {
-        ShowLaws.check(show: Validated.show(), generator: { a in (a % 2 == 0) ? Validated.valid(a) : Validated.invalid(a) })
+        ShowLaws.check(show: Validated.show(), generator: self.generator)
+    }
+    
+    func testFoldableLaws() {
+        FoldableLaws<ValidatedPartial<Int>>.check(foldable: Validated<Int, Int>.foldable(), generator: self.generator)
     }
 }

--- a/Tests/BowTests/Instances/BoolInstancesTest.swift
+++ b/Tests/BowTests/Instances/BoolInstancesTest.swift
@@ -15,17 +15,16 @@ class BoolInstancesTest: XCTestCase {
     }
     
     func testBoolMonoidLaws() {
-        property("And monoid laws") <- forAll { (a : Bool, b : Bool, c : Bool) in
-            return SemigroupLaws.check(semigroup: Bool.andMonoid, a: a, b: b, c: c, eq: Bool.eq)
+        property("And monoid laws") <- forAll { (a : Bool) in
+            return MonoidLaws.check(monoid: Bool.andMonoid, a: a, eq: Bool.eq)
         }
         
-        property("Or monoid laws") <- forAll { (a : Bool, b : Bool, c : Bool) in
-            return SemigroupLaws.check(semigroup: Bool.orMonoid, a: a, b: b, c: c, eq: Bool.eq)
+        property("Or monoid laws") <- forAll { (a : Bool) in
+            return MonoidLaws.check(monoid: Bool.orMonoid, a: a, eq: Bool.eq)
         }
     }
     
     func testEqLaws() {
         EqLaws.check(eq: Bool.eq, generator: id)
     }
-    
 }

--- a/Tests/BowTests/Optics/Laws/IsoLaws.swift
+++ b/Tests/BowTests/Optics/Laws/IsoLaws.swift
@@ -39,7 +39,7 @@ class IsoLaws<A, B> where A : Arbitrary, B : Arbitrary, B : CoArbitrary, B : Has
     
     private static func consistentSetModify<EqA>(_ iso : Iso<A, B>, _ eqA : EqA) where EqA : Eq, EqA.A == A {
         property("Consistent set-modify") <- forAll { (a : A, b : B) in
-            return eqA.eqv(iso.set(b), iso.modify(a, constF(b)))
+            return eqA.eqv(iso.set(b), iso.modify(a, constant(b)))
         }
     }
     

--- a/Tests/BowTests/Optics/Laws/LensLaws.swift
+++ b/Tests/BowTests/Optics/Laws/LensLaws.swift
@@ -48,7 +48,7 @@ class LensLaws<A, B> where A : Arbitrary, B : Arbitrary, B : CoArbitrary, B : Ha
     private static func consistentSetModify<EqA>(_ lens : Lens<A, B>, _ eqA : EqA) where EqA : Eq, EqA.A == A {
         property("Consistent set - modify") <- forAll { (a : A, b : B) in
             return eqA.eqv(lens.set(a, b),
-                           lens.modify(a, constF(b)))
+                           lens.modify(a, constant(b)))
         }
     }
     

--- a/Tests/BowTests/Optics/Laws/OptionalLaws.swift
+++ b/Tests/BowTests/Optics/Laws/OptionalLaws.swift
@@ -24,7 +24,7 @@ class OptionalLaws<A, B> where A : Arbitrary, B : Arbitrary, B : CoArbitrary, B 
     private static func setGetMaybe<EqMaybeB>(_ optional : Bow.Optional<A, B>, _ eqB : EqMaybeB) where EqMaybeB : Eq, EqMaybeB.A == MaybeOf<B> {
         property("set - getMaybe") <- forAll { (a : A, b : B) in
             return eqB.eqv(optional.getMaybe(optional.set(a, b)),
-                           optional.getMaybe(a).map(constF(b)))
+                           optional.getMaybe(a).map(constant(b)))
         }
     }
     
@@ -51,7 +51,7 @@ class OptionalLaws<A, B> where A : Arbitrary, B : Arbitrary, B : CoArbitrary, B 
     private static func consistentSetModify<EqA>(_ optional : Bow.Optional<A, B>, _ eqA : EqA) where EqA : Eq, EqA.A == A {
         property("Consistent set - modify") <- forAll { (a : A, b : B) in
             return eqA.eqv(optional.set(a, b),
-                           optional.modify(a, constF(b)))
+                           optional.modify(a, constant(b)))
         }
     }
     
@@ -88,6 +88,6 @@ fileprivate class OptionalMonoid<B> : Monoid {
     }
     
     func combine(_ a: FirstMaybe<B>, _ b: FirstMaybe<B>) -> FirstMaybe<B> {
-        return a.maybe.fold(constF(false), constF(true)) ? a : b
+        return a.maybe.fold(constant(false), constant(true)) ? a : b
     }
 }

--- a/Tests/BowTests/Optics/Laws/PrismLaws.swift
+++ b/Tests/BowTests/Optics/Laws/PrismLaws.swift
@@ -42,7 +42,7 @@ class PrismLaws<A, B> where A : Arbitrary, B : Arbitrary, B : CoArbitrary, B : H
     private static func consistentSetModify<EqA>(_ prism : Prism<A, B>, _ eqA : EqA) where EqA : Eq, EqA.A == A {
         property("Consistent set - modify") <- forAll { (a : A, b : B) in
             return eqA.eqv(prism.set(a, b),
-                           prism.modify(a, constF(b)))
+                           prism.modify(a, constant(b)))
         }
     }
     

--- a/Tests/BowTests/Optics/Laws/SetterLaws.swift
+++ b/Tests/BowTests/Optics/Laws/SetterLaws.swift
@@ -33,7 +33,7 @@ class SetterLaws<A, B> where A : Arbitrary, B : Arbitrary, B : CoArbitrary, B : 
     private static func consistentSetModify<EqA>(_ setter : Setter<A, B>, _ eqA : EqA) where EqA : Eq, EqA.A == A {
         property("Consistent set - modify") <- forAll { (a : A, b : B) in
             return eqA.eqv(setter.set(a, b),
-                           setter.modify(a, constF(b)))
+                           setter.modify(a, constant(b)))
         }
     }
 }

--- a/Tests/BowTests/PredefTest.swift
+++ b/Tests/BowTests/PredefTest.swift
@@ -11,27 +11,27 @@ class PredefTest : XCTestCase {
     }
     
     func testConstF() {
-        property("ConstF must create an argument-less function that always return a constant value") <- forAll() { (a : Int) in
+        property("constant must create an argument-less function that always return a constant value") <- forAll() { (a : Int) in
             let f : () -> Int = constant(a)
             return f() == a
         }
         
-        property("ConstF must create a one argument function that always return a constant value") <- forAll() { (a : Int, b : Int) in
+        property("constant must create a one argument function that always return a constant value") <- forAll() { (a : Int, b : Int) in
             let f : (Int) -> Int = constant(a)
             return f(b) == a
         }
         
-        property("ConstF must create a two argument function that always return a constant value") <- forAll() { (a : Int, b : Int, c : Int) in
+        property("constant must create a two argument function that always return a constant value") <- forAll() { (a : Int, b : Int, c : Int) in
             let f : (Int, Int) -> Int = constant(a)
             return f(b, c) == a
         }
         
-        property("ConstF must create a three argument function that always return a constant value") <- forAll() { (a : Int, b : Int, c : Int, d : Int) in
+        property("constant must create a three argument function that always return a constant value") <- forAll() { (a : Int, b : Int, c : Int, d : Int) in
             let f : (Int, Int, Int) -> Int = constant(a)
             return f(b, c, d) == a
         }
         
-        property("ConstF must create a four argument function that always return a constant value") <- forAll() { (a : Int, b : Int, c : Int, d : Int, e : Int) in
+        property("constant must create a four argument function that always return a constant value") <- forAll() { (a : Int, b : Int, c : Int, d : Int, e : Int) in
             let f : (Int, Int, Int, Int) -> Int = constant(a)
             return f(b, c, d, e) == a
         }

--- a/Tests/BowTests/PredefTest.swift
+++ b/Tests/BowTests/PredefTest.swift
@@ -12,27 +12,27 @@ class PredefTest : XCTestCase {
     
     func testConstF() {
         property("ConstF must create an argument-less function that always return a constant value") <- forAll() { (a : Int) in
-            let f : () -> Int = constF(a)
+            let f : () -> Int = constant(a)
             return f() == a
         }
         
         property("ConstF must create a one argument function that always return a constant value") <- forAll() { (a : Int, b : Int) in
-            let f : (Int) -> Int = constF(a)
+            let f : (Int) -> Int = constant(a)
             return f(b) == a
         }
         
         property("ConstF must create a two argument function that always return a constant value") <- forAll() { (a : Int, b : Int, c : Int) in
-            let f : (Int, Int) -> Int = constF(a)
+            let f : (Int, Int) -> Int = constant(a)
             return f(b, c) == a
         }
         
         property("ConstF must create a three argument function that always return a constant value") <- forAll() { (a : Int, b : Int, c : Int, d : Int) in
-            let f : (Int, Int, Int) -> Int = constF(a)
+            let f : (Int, Int, Int) -> Int = constant(a)
             return f(b, c, d) == a
         }
         
         property("ConstF must create a four argument function that always return a constant value") <- forAll() { (a : Int, b : Int, c : Int, d : Int, e : Int) in
-            let f : (Int, Int, Int, Int) -> Int = constF(a)
+            let f : (Int, Int, Int, Int) -> Int = constant(a)
             return f(b, c, d, e) == a
         }
     }
@@ -71,9 +71,9 @@ class PredefTest : XCTestCase {
         }
         
         property("Function composition is associative") <- forAll() { (a : Int, b : Int, c : Int, x : Int) in
-            let f : (Int) -> Int = constF(a)
-            let g : (Int) -> Int = constF(b)
-            let h : (Int) -> Int = constF(c)
+            let f : (Int) -> Int = constant(a)
+            let g : (Int) -> Int = constant(b)
+            let h : (Int) -> Int = constant(c)
             
             return ((h <<< g) <<< f)(x) == (h <<< (g <<< f))(x)
         }

--- a/Tests/BowTests/PredefTest.swift
+++ b/Tests/BowTests/PredefTest.swift
@@ -38,44 +38,35 @@ class PredefTest : XCTestCase {
     }
     
     func testComposition() {
-        property("Function composition is equal to applying functions sequentially") <- forAll() { (a : Int, b : String) in
-            let f = { a }
-            let g = { (_ : Int) in b }
+        property("Function composition is equal to applying functions sequentially") <- forAll() { (a : Int, g : ArrowOf<Int, String>) in
+            let f = constant(a)
             let x1 = f()
-            let x2 = g(x1)
-            return x2 == (g <<< f)()
+            let x2 = g.getArrow(x1)
+            return x2 == (g.getArrow <<< f)()
         }
         
-        property("Function composition is equal to applying functions sequentially") <- forAll() { (a : Int, b : String, x1 : Int) in
-            let f = { (_ : Int) in a }
-            let g = { (_ : Int) in b }
-            let x2 = f(x1)
-            let x3 = g(x2)
-            return x3 == (g <<< f)(x1)
+        property("Function composition is equal to applying functions sequentially") <- forAll() { (f : ArrowOf<Int, Int>, g : ArrowOf<Int, String>, x1 : Int) in
+            let x2 = f.getArrow(x1)
+            let x3 = g.getArrow(x2)
+            return x3 == (g.getArrow <<< f.getArrow)(x1)
         }
         
-        property("Function composition is equal to applying functions sequentially") <- forAll() { (a : Int, b : String) in
-            let f = { a }
-            let g = { (_ : Int) in b }
+        property("Function composition is equal to applying functions sequentially") <- forAll() { (a : Int, g : ArrowOf<Int, String>) in
+            let f = constant(a)
             let x1 = f()
-            let x2 = g(x1)
-            return x2 == compose(g, f)()
+            let x2 = g.getArrow(x1)
+            return x2 == compose(g.getArrow, f)()
         }
         
-        property("Function composition is equal to applying functions sequentially") <- forAll() { (a : Int, b : String, x1 : Int) in
-            let f = { (_ : Int) in a }
-            let g = { (_ : Int) in b }
-            let x2 = f(x1)
-            let x3 = g(x2)
-            return x3 == compose(g, f)(x1)
+        property("Function composition is equal to applying functions sequentially") <- forAll() { (f : ArrowOf<Int, Int>, g : ArrowOf<Int, String>, x1 : Int) in
+            let x2 = f.getArrow(x1)
+            let x3 = g.getArrow(x2)
+            return x3 == compose(g.getArrow, f.getArrow)(x1)
         }
         
-        property("Function composition is associative") <- forAll() { (a : Int, b : Int, c : Int, x : Int) in
-            let f : (Int) -> Int = constant(a)
-            let g : (Int) -> Int = constant(b)
-            let h : (Int) -> Int = constant(c)
+        property("Function composition is associative") <- forAll() { (f : ArrowOf<Int, Int>, g : ArrowOf<Int, Int>, h : ArrowOf<Int, Int>, x : Int) in
             
-            return ((h <<< g) <<< f)(x) == (h <<< (g <<< f))(x)
+            return ((h.getArrow <<< g.getArrow) <<< f.getArrow)(x) == (h.getArrow <<< (g.getArrow <<< f.getArrow))(x)
         }
     }
 }

--- a/Tests/BowTests/Transformers/EitherTTest.swift
+++ b/Tests/BowTests/Transformers/EitherTTest.swift
@@ -1,8 +1,9 @@
 import XCTest
+import SwiftCheck
 @testable import Bow
 
 class EitherTTest: XCTestCase {
-    var generator : (Int) -> EitherTOf<ForId, Int, Int> {
+    var generator : (Int) -> EitherT<ForId, Int, Int> {
         return { a in EitherT.pure(a, Id<Int>.applicative()) }
     }
     
@@ -46,5 +47,15 @@ class EitherTTest: XCTestCase {
     
     func testSemigroupKLaws() {
         SemigroupKLaws<EitherTPartial<ForId, Int>>.check(semigroupK: EitherT<ForId, Int, Int>.semigroupK(Id<Any>.monad()), generator: self.generator, eq: self.eq)
+    }
+    
+    func testSemigroupLaws() {
+        property("Semigroup laws") <- forAll { (a : Int, b : Int, c : Int) in
+            return SemigroupLaws.check(semigroup: EitherT<ForId, Int, Int>.semigroupK(Id<Any>.monad()).algebra(),
+                                       a: self.generator(a),
+                                       b: self.generator(b),
+                                       c: self.generator(c),
+                                       eq: self.eq)
+        }
     }
 }

--- a/Tests/BowTests/Transformers/MaybeTTest.swift
+++ b/Tests/BowTests/Transformers/MaybeTTest.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SwiftCheck
 @testable import Bow
 
 class MaybeTTest: XCTestCase {
@@ -30,8 +31,26 @@ class MaybeTTest: XCTestCase {
         SemigroupKLaws<MaybeTPartial<ForId>>.check(semigroupK: MaybeT<ForId, Int>.semigroupK(Id<Any>.monad()), generator: self.generator, eq: self.eq)
     }
     
+    func testSemigroupLaws() {
+        property("Semigroup laws") <- forAll { (a : Int, b : Int, c : Int) in
+            return SemigroupLaws.check(semigroup: MaybeT<ForId, Int>.semigroupK(Id<Int>.monad()).algebra(),
+                                       a: MaybeT<ForId, Int>.pure(a, Id<Int>.applicative()),
+                                       b: MaybeT<ForId, Int>.pure(b, Id<Int>.applicative()),
+                                       c: MaybeT<ForId, Int>.pure(c, Id<Int>.applicative()),
+                                       eq: self.eq)
+        }
+    }
+    
     func testMonoidKLaws() {
         MonoidKLaws<MaybeTPartial<ForId>>.check(monoidK: MaybeT<ForId, Int>.monoidK(Id<Any>.monad()), generator: self.generator, eq: self.eq)
+    }
+    
+    func testMonoidLaws() {
+        property("Monoid laws") <- forAll { (a : Int) in
+            return MonoidLaws.check(monoid: MaybeT<ForId, Int>.monoidK(Id<Int>.monad()).algebra(),
+                                    a: MaybeT<ForId, Int>.pure(a, Id<Int>.applicative()),
+                                    eq: self.eq)
+        }
     }
     
     func testFunctorFilterLaws() {

--- a/Tests/BowTests/Transformers/StateTTest.swift
+++ b/Tests/BowTests/Transformers/StateTTest.swift
@@ -99,4 +99,8 @@ class StateTTest: XCTestCase {
             eq: StateTPointEq(),
             eqUnit: StateTIdUnitEq())
     }
+    
+    func testMonadCombineLaws() {
+        MonadCombineLaws<StateTPartial<ForListK, Int>>.check(monadCombine: StateT<ForListK, Int, Int>.monadCombine(ListK<Int>.monadCombine()), eq: StateTListKEq())
+    }
 }

--- a/Tests/BowTests/Transformers/StateTTest.swift
+++ b/Tests/BowTests/Transformers/StateTTest.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SwiftCheck
 @testable import Bow
 
 class StateTTest: XCTestCase {
@@ -91,6 +92,16 @@ class StateTTest: XCTestCase {
             semigroupK: StateT<ForListK, Int, Int>.semigroupK(ListK<Int>.monad(), ListK<Int>.semigroupK()),
             generator: { (a : Int) in StateT<ForListK, Int, Int>.applicative(ListK<Int>.monad()).pure(a) },
             eq: StateTListKEq())
+    }
+    
+    func testSemigroupLaws() {
+        property("Semigroup laws") <- forAll { (a : Int, b : Int, c : Int) in
+            return SemigroupLaws.check(semigroup: StateT<ForListK, Int, Int>.semigroupK(ListK<Int>.monad(), ListK<Int>.semigroupK()).algebra(),
+                                       a: StateT<ForListK, Int, Int>.applicative(ListK<Int>.monad()).pure(a),
+                                       b: StateT<ForListK, Int, Int>.applicative(ListK<Int>.monad()).pure(b),
+                                       c: StateT<ForListK, Int, Int>.applicative(ListK<Int>.monad()).pure(c),
+                                       eq: StateTListKEq())
+        }
     }
     
     func testMonadStateLaws() {

--- a/Tests/BowTests/Transformers/WriterTTest.swift
+++ b/Tests/BowTests/Transformers/WriterTTest.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SwiftCheck
 @testable import Bow
 
 class WriterTTest: XCTestCase {
@@ -33,11 +34,29 @@ class WriterTTest: XCTestCase {
             eq: WriterT<ForListK, Int, Int>.eq(ListK.eq(Tuple.eq(Int.order, Int.order))))
     }
     
+    func testSemigroupLaws() {
+        property("Semigroup laws") <- forAll { (a : Int, b : Int, c : Int) in
+            return SemigroupLaws.check(semigroup: WriterT<ForListK, Int, Int>.semigroupK(ListK<Int>.semigroupK()).algebra(),
+                                       a: WriterT.pure(a, Int.sumMonoid, ListK<Int>.applicative()),
+                                       b: WriterT.pure(b, Int.sumMonoid, ListK<Int>.applicative()),
+                                       c: WriterT.pure(c, Int.sumMonoid, ListK<Int>.applicative()),
+                                       eq: WriterT<ForListK, Int, Int>.eq(ListK.eq(Tuple.eq(Int.order, Int.order))))
+        }
+    }
+    
     func testMonoidKLaws() {
         MonoidKLaws<WriterTPartial<ForListK, Int>>.check(
             monoidK: WriterT<ForListK, Int, Int>.monoidK(ListK<Int>.monoidK()),
             generator: { (a : Int) in WriterT.pure(a, Int.sumMonoid, ListK<Int>.applicative()) },
             eq: WriterT<ForListK, Int, Int>.eq(ListK.eq(Tuple.eq(Int.order, Int.order))))
+    }
+    
+    func testMonoidLaws() {
+        property("Monoid laws") <- forAll { (a : Int) in
+            return MonoidLaws.check(monoid: WriterT<ForListK, Int, Int>.monoidK(ListK<Int>.monoidK()).algebra(),
+                                    a: WriterT.pure(a, Int.sumMonoid, ListK<Int>.applicative()),
+                                    eq: WriterT<ForListK, Int, Int>.eq(ListK.eq(Tuple.eq(Int.order, Int.order))))
+        }
     }
     
     func testFunctorFilterLaws() {

--- a/Tests/BowTests/Typeclasses/AlternativeLaws.swift
+++ b/Tests/BowTests/Typeclasses/AlternativeLaws.swift
@@ -1,0 +1,39 @@
+import SwiftCheck
+@testable import Bow
+
+class AlternativeLaws<F> {
+    
+    public static func check<Alt, EqA>(alternative : Alt, eq : EqA) where Alt : Alternative, Alt.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
+        rightAbsorption(alternative, eq)
+        leftDistributivity(alternative, eq)
+        rightDistributivity(alternative, eq)
+    }
+    
+    private static func rightAbsorption<Alt, EqA>(_ alternative : Alt, _ eq : EqA) where Alt : Alternative, Alt.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
+        property("Right absorption") <- forAll { (f : ArrowOf<Int, Int>) in
+            return eq.eqv(alternative.ap(alternative.emptyK(), alternative.pure(f.getArrow)),
+                          alternative.emptyK())
+        }
+    }
+    
+    private static func leftDistributivity<Alt, EqA>(_ alternative : Alt, _ eq : EqA) where Alt : Alternative, Alt.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
+        property("Left distributivity") <- forAll { (x : Int, y : Int, f : ArrowOf<Int, Int>) in
+            return eq.eqv(alternative.map(alternative.combineK(alternative.pure(x),
+                                                               alternative.pure(y)), f.getArrow),
+                          alternative.combineK(alternative.map(alternative.pure(x), f.getArrow),
+                                               alternative.map(alternative.pure(y), f.getArrow)))
+        }
+    }
+    
+    private static func rightDistributivity<Alt, EqA>(_ alternative : Alt, _ eq : EqA) where Alt : Alternative, Alt.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
+        property("Left distributivity") <- forAll { (x : Int, f : ArrowOf<Int, Int>, g : ArrowOf<Int, Int>) in
+            return eq.eqv(alternative.ap(alternative.pure(x),
+                                         alternative.combineK(alternative.pure(f.getArrow),
+                                                              alternative.pure(g.getArrow))),
+                          alternative.combineK(alternative.ap(alternative.pure(x),
+                                                              alternative.pure(f.getArrow)),
+                                               alternative.ap(alternative.pure(x),
+                                                              alternative.pure(g.getArrow))))
+        }
+    }
+}

--- a/Tests/BowTests/Typeclasses/ApplicativeErrorLaws.swift
+++ b/Tests/BowTests/Typeclasses/ApplicativeErrorLaws.swift
@@ -10,6 +10,10 @@ enum CategoryError : Error {
     static var eq : CategoryErrorEq {
         return CategoryErrorEq()
     }
+    
+    static var semigroup : CategoryErrorSemigroup {
+        return CategoryErrorSemigroup()
+    }
 }
 
 class CategoryErrorEq : Eq {
@@ -19,6 +23,18 @@ class CategoryErrorEq : Eq {
         switch (a, b) {
         case (.common, .common), (.fatal, .fatal), (.unknown, .unknown): return true
         default: return false
+        }
+    }
+}
+
+class CategoryErrorSemigroup : Semigroup {
+    typealias A = CategoryError
+    
+    func combine(_ a: CategoryError, _ b: CategoryError) -> CategoryError {
+        switch (a, b) {
+        case (.fatal, _), (_, .fatal): return .fatal
+        case (.common, _), (_, .common): return .common
+        default: return .unknown
         }
     }
 }

--- a/Tests/BowTests/Typeclasses/ApplicativeLaws.swift
+++ b/Tests/BowTests/Typeclasses/ApplicativeLaws.swift
@@ -22,7 +22,7 @@ class ApplicativeLaws<F> {
     
     private static func homomorphism<Appl, EqA>(applicative : Appl, eq : EqA) where Appl : Applicative, Appl.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
         property("homomorphism") <- forAll() { (a : Int, b : Int) in
-            let f : (Int) -> Int = constF(b)
+            let f : (Int) -> Int = constant(b)
             return eq.eqv(applicative.ap(applicative.pure(a), applicative.pure(f)),
                           applicative.pure(f(a)))
         }
@@ -30,7 +30,7 @@ class ApplicativeLaws<F> {
     
     private static func interchange<Appl, EqA>(applicative : Appl, eq : EqA) where Appl : Applicative, Appl.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
         property("interchange") <- forAll() { (a : Int, b : Int) in
-            let fa = applicative.pure(constF(a) as (Int) -> Int)
+            let fa = applicative.pure(constant(a) as (Int) -> Int)
             return eq.eqv(applicative.ap(applicative.pure(b), fa),
                           applicative.ap(fa, applicative.pure({ (x : (Int) -> Int) in x(a) } )))
         }
@@ -38,7 +38,7 @@ class ApplicativeLaws<F> {
     
     private static func mapDerived<Appl, EqA>(applicative : Appl, eq : EqA) where Appl : Applicative, Appl.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
         property("mad derived") <- forAll() { (a : Int, b : Int) in
-            let f : (Int) -> Int = constF(b)
+            let f : (Int) -> Int = constant(b)
             let fa = applicative.pure(a)
             return eq.eqv(applicative.map(fa, f),
                           applicative.ap(fa, applicative.pure(f)))

--- a/Tests/BowTests/Typeclasses/ApplicativeLaws.swift
+++ b/Tests/BowTests/Typeclasses/ApplicativeLaws.swift
@@ -11,6 +11,7 @@ class ApplicativeLaws<F> {
         mapDerived(applicative: applicative, eq: eq)
         cartesianBuilderMap(applicative: applicative, eq: eq)
         cartesianBuilderTupled(applicative: applicative, eq: eq)
+        mapWithMultipleInputs(applicative: applicative, eq: eq)
     }
     
     private static func apIdentity<Appl, EqA>(applicative : Appl, eq : EqA) where Appl : Applicative, Appl.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
@@ -57,6 +58,48 @@ class ApplicativeLaws<F> {
         property("cartesian builder map") <- forAll() { (a : Int, b : Int, c : Int, d : Int, e : Int, f : Int, g : Int) in
             return eq.eqv(applicative.map(applicative.tupled(applicative.pure(a), applicative.pure(b), applicative.pure(c), applicative.pure(d), applicative.pure(e), applicative.pure(f)), { x, y, z, u, v, w in x + y + z - u - v - w }),
                           applicative.pure(a + b + c - d - e - f))
+        }
+    }
+    
+    private static func mapWithMultipleInputs<Appl, EqA>(applicative : Appl, eq : EqA) where Appl : Applicative, Appl.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
+        property("Map with 2 inputs") <- forAll { (a : Int, b : Int) in
+            return eq.eqv(applicative.map(applicative.pure(a), applicative.pure(b), { a1, b1 in a1 + b1 }),
+                          applicative.pure(a + b))
+        }
+        
+        property("Map with 3 inputs") <- forAll { (a : Int, b : Int, c : Int) in
+            return eq.eqv(applicative.map(applicative.pure(a), applicative.pure(b), applicative.pure(c), { a1, b1, c1 in a1 + b1 + c1 }),
+                          applicative.pure(a + b + c))
+        }
+        
+        property("Map with 4 inputs") <- forAll { (a : Int, b : Int, c : Int, d : Int) in
+            return eq.eqv(applicative.map(applicative.pure(a), applicative.pure(b), applicative.pure(c), applicative.pure(d), { a1, b1, c1, d1 in a1 + b1 + c1 + d1 }),
+                          applicative.pure(a + b + c + d))
+        }
+        
+        property("Map with 5 inputs") <- forAll { (a : Int, b : Int, c : Int, d : Int, e : Int) in
+            return eq.eqv(applicative.map(applicative.pure(a), applicative.pure(b), applicative.pure(c), applicative.pure(d), applicative.pure(e), { a1, b1, c1, d1, e1 in a1 + b1 + c1 + d1 + e1 }),
+                          applicative.pure(a + b + c + d + e))
+        }
+
+        property("Map with 6 inputs") <- forAll { (a : Int, b : Int, c : Int, d : Int, e : Int, f : Int) in
+            return eq.eqv(applicative.map(applicative.pure(a), applicative.pure(b), applicative.pure(c), applicative.pure(d), applicative.pure(e), applicative.pure(f), { a1, b1, c1, d1, e1, f1 in a1 + b1 + c1 + d1 + e1 + f1 }),
+                          applicative.pure(a + b + c + d + e + f))
+        }
+        
+        property("Map with 7 inputs") <- forAll { (a : Int, b : Int, c : Int, d : Int, e : Int, f : Int, g : Int) in
+            return eq.eqv(applicative.map(applicative.pure(a), applicative.pure(b), applicative.pure(c), applicative.pure(d), applicative.pure(e), applicative.pure(f), applicative.pure(g), { a1, b1, c1, d1, e1, f1, g1 in a1 + b1 + c1 + d1 + e1 + f1 + g1 }),
+                          applicative.pure(a + b + c + d + e + f + g))
+        }
+        
+        property("Map with 8 inputs") <- forAll { (a : Int, b : Int, c : Int, d : Int, e : Int, f : Int, g : Int, h : Int) in
+            return eq.eqv(applicative.map(applicative.pure(a), applicative.pure(b), applicative.pure(c), applicative.pure(d), applicative.pure(e), applicative.pure(f), applicative.pure(g), applicative.pure(h), { a1, b1, c1, d1, e1, f1, g1, h1 in a1 + b1 + c1 + d1 + e1 + f1 + g1 + h1 }),
+                          applicative.pure(a + b + c + d + e + f + g + h))
+        }
+        
+        property("Map with 9 inputs") <- forAll { (a : Int, b : Int, c : Int, d : Int, e : Int, f : Int, g : Int, h : Int) in
+            return eq.eqv(applicative.map(applicative.pure(a), applicative.pure(b), applicative.pure(c), applicative.pure(d), applicative.pure(e), applicative.pure(f), applicative.pure(g), applicative.pure(h), applicative.pure(a), { a1, b1, c1, d1, e1, f1, g1, h1, i1 in a1 + b1 + c1 + d1 + e1 + f1 + g1 + h1 + i1 }),
+                          applicative.pure(a + b + c + d + e + f + g + h + a))
         }
     }
 }

--- a/Tests/BowTests/Typeclasses/BimonadLaws.swift
+++ b/Tests/BowTests/Typeclasses/BimonadLaws.swift
@@ -1,0 +1,9 @@
+@testable import Bow
+
+class BimonadLaws<F> {
+    
+    static func check<Bimon, EqF>(bimonad : Bimon, generator : @escaping (Int) -> Kind<F, Int>, eq : EqF) where Bimon : Bimonad, Bimon.F == F, EqF : Eq, EqF.A == Kind<F, Int> {
+        MonadLaws<F>.check(monad: bimonad, eq: eq)
+        ComonadLaws<F>.check(comonad: bimonad, generator: generator, eq: eq)
+    }
+}

--- a/Tests/BowTests/Typeclasses/FoldableLaws.swift
+++ b/Tests/BowTests/Typeclasses/FoldableLaws.swift
@@ -1,0 +1,61 @@
+import SwiftCheck
+@testable import Bow
+
+class FoldableLaws<F> {
+    public static func check<FoldableType>(foldable : FoldableType, generator : @escaping (Int) -> Kind<F, Int>) where FoldableType : Foldable, FoldableType.F == F {
+        leftFoldConsistentWithFoldMap(foldable, generator)
+        existsConsistentWithFind(foldable, generator)
+        forallConsistentWithExists(foldable, generator)
+        forallReturnsTrueIfEmpty(foldable, generator)
+        foldMIdIsFoldL(foldable, generator)
+    }
+    
+    private static func leftFoldConsistentWithFoldMap<FoldableType>(_ foldable : FoldableType, _ generator : @escaping (Int) -> Kind<F, Int>) where FoldableType : Foldable, FoldableType.F == F {
+        property("Left fold consistent with foldMap") <- forAll { (x : Int, f : ArrowOf<Int, Int>) in
+            let input = generator(x)
+            
+            return foldable.foldMap(Int.sumMonoid, input, f.getArrow) ==
+                foldable.foldL(input, Int.sumMonoid.empty, { b, a in Int.sumMonoid.combine(b, f.getArrow(a)) })
+        }
+    }
+    
+    private static func existsConsistentWithFind<FoldableType>(_ foldable : FoldableType, _ generator : @escaping (Int) -> Kind<F, Int>) where FoldableType : Foldable, FoldableType.F == F {
+        property("Exists consistent with find") <- forAll { (x : Int, predicate : ArrowOf<Int, Bool>) in
+            let input = generator(x)
+            
+            return foldable.exists(input, predicate.getArrow) ==
+                    foldable.find(input, predicate.getArrow).fold(constant(false), constant(true))
+        }
+    }
+    
+    private static func forallConsistentWithExists<FoldableType>(_ foldable : FoldableType, _ generator : @escaping (Int) -> Kind<F, Int>) where FoldableType : Foldable, FoldableType.F == F {
+        property("Forall consistent with exists") <- forAll { (x : Int, predicate : ArrowOf<Int, Bool>) in
+            let input = generator(x)
+            
+            if foldable.forall(input, predicate.getArrow) {
+                let negationExists = foldable.exists(input, predicate.getArrow >>> not)
+                return !negationExists && (foldable.isEmpty(input) || foldable.exists(input, predicate.getArrow))
+            } else {
+                return true
+            }
+        }
+    }
+    
+    private static func forallReturnsTrueIfEmpty<FoldableType>(_ foldable : FoldableType, _ generator : @escaping (Int) -> Kind<F, Int>) where FoldableType : Foldable, FoldableType.F == F {
+        property("Forall returns true if empty") <- forAll { (x : Int, predicate : ArrowOf<Int, Bool>) in
+            let input = generator(x)
+            
+            return !foldable.isEmpty(input) || foldable.forall(input, predicate.getArrow)
+        }
+    }
+    
+    private static func foldMIdIsFoldL<FoldableType>(_ foldable : FoldableType, _ generator : @escaping (Int) -> Kind<F, Int>) where FoldableType : Foldable, FoldableType.F == F {
+        property("Exists consistent with find") <- forAll { (x : Int, f : ArrowOf<Int, Int>) in
+            let input = generator(x)
+            
+            let foldL = foldable.foldL(input, Int.sumMonoid.empty, { b, a in Int.sumMonoid.combine(b, f.getArrow(a)) })
+            let foldM = foldable.foldM(input, Int.sumMonoid.empty, { b, a in Id(Int.sumMonoid.combine(b, f.getArrow(a))) }, Id<Int>.monad()).fix().value
+            return foldL == foldM
+        }
+    }
+}

--- a/Tests/BowTests/Typeclasses/FunctorLaws.swift
+++ b/Tests/BowTests/Typeclasses/FunctorLaws.swift
@@ -21,8 +21,8 @@ class FunctorLaws<F> {
     
     private static func covariantComposition<Func, EqA>(_ functor : Func, _ generator : @escaping (Int) -> Kind<F, Int>, _ eq : EqA) where Func : Functor, Func.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
         property("Composition is preserved under functor transformation") <- forAll() { (a : Int, b : Int, c : Int) in
-            let f : (Int) -> Int = constF(b)
-            let g : (Int) -> Int = constF(c)
+            let f : (Int) -> Int = constant(b)
+            let g : (Int) -> Int = constant(c)
             let fa = generator(a)
             return eq.eqv(functor.map(functor.map(fa, f), g), functor.map(fa, f >>> g))
         }

--- a/Tests/BowTests/Typeclasses/MonadCombineLaws.swift
+++ b/Tests/BowTests/Typeclasses/MonadCombineLaws.swift
@@ -1,0 +1,8 @@
+@testable import Bow
+
+class MonadCombineLaws<F> {
+    static func check<MonComb, EqA>(monadCombine : MonComb, eq : EqA) where MonComb : MonadCombine, MonComb.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
+        AlternativeLaws.check(alternative: monadCombine, eq: eq)
+        MonadFilterLaws.check(monadFilter: monadCombine, generator: monadCombine.pure, eq: eq)
+    }
+}

--- a/Tests/BowTests/Typeclasses/MonadFilterLaws.swift
+++ b/Tests/BowTests/Typeclasses/MonadFilterLaws.swift
@@ -20,7 +20,7 @@ class MonadFilterLaws<F> {
     private static func rightEmpty<MonFil, EqF>(_ monadFilter : MonFil, _ generator : @escaping (Int) -> Kind<F, Int>, _ eq : EqF) where MonFil : MonadFilter, MonFil.F == F, EqF : Eq, EqF.A == Kind<F, Int> {
         property("Right empty") <- forAll { (a : Int) in
             let fa = generator(a)
-            return eq.eqv(monadFilter.flatMap(fa, constF(monadFilter.empty())),
+            return eq.eqv(monadFilter.flatMap(fa, constant(monadFilter.empty())),
                           monadFilter.empty())
         }
     }

--- a/Tests/BowTests/Typeclasses/MonadLaws.swift
+++ b/Tests/BowTests/Typeclasses/MonadLaws.swift
@@ -13,6 +13,7 @@ class MonadLaws<F> {
         flatMapCoherence(monad, eq)
         stackSafety(monad, eq)
         monadComprehensions(monad, eq)
+        flatten(monad, eq)
     }
     
     private static func leftIdentity<Mon, EqF>(_ monad : Mon, _ eq : EqF) where Mon : Monad, Mon.F == F, EqF : Eq, EqF.A == Kind<F, Int> {
@@ -65,9 +66,85 @@ class MonadLaws<F> {
     private static func monadComprehensions<Mon, EqF>(_ monad : Mon, _ eq : EqF) where Mon : Monad, Mon.F == F, EqF : Eq, EqF.A == Kind<F, Int> {
         property("Monad comprehensions") <- forAll { (a : Int) in
             let x = monad.binding({ monad.pure(a) },
+                                  { a in monad.pure(a + 1) })
+            return eq.eqv(x, monad.pure(a + 1))
+        }
+        
+        property("Monad comprehensions") <- forAll { (a : Int) in
+            let x = monad.binding({ monad.pure(a) },
                                   { a in monad.pure(a + 1) },
                                   { _, b in monad.pure(b + 1) })
             return eq.eqv(x, monad.pure(a + 2))
+        }
+        
+        property("Monad comprehensions") <- forAll { (a : Int) in
+            let x = monad.binding({ monad.pure(a) },
+                                  { a in monad.pure(a + 1) },
+                                  { _, b in monad.pure(b + 1) },
+                                  { _, _, c in monad.pure(c + 1) })
+            return eq.eqv(x, monad.pure(a + 3))
+        }
+        
+        property("Monad comprehensions") <- forAll { (a : Int) in
+            let x = monad.binding({ monad.pure(a) },
+                                  { a in monad.pure(a + 1) },
+                                  { _, b in monad.pure(b + 1) },
+                                  { _, _, c in monad.pure(c + 1) },
+                                  { _, _, _, d in monad.pure(d + 1) })
+            return eq.eqv(x, monad.pure(a + 4))
+        }
+        
+        property("Monad comprehensions") <- forAll { (a : Int) in
+            let x = monad.binding({ monad.pure(a) },
+                                  { a in monad.pure(a + 1) },
+                                  { _, b in monad.pure(b + 1) },
+                                  { _, _, c in monad.pure(c + 1) },
+                                  { _, _, _, d in monad.pure(d + 1) },
+                                  { _, _, _, _, e in monad.pure(e + 1) })
+            return eq.eqv(x, monad.pure(a + 5))
+        }
+        
+        property("Monad comprehensions") <- forAll { (a : Int) in
+            let x = monad.binding({ monad.pure(a) },
+                                  { a in monad.pure(a + 1) },
+                                  { _, b in monad.pure(b + 1) },
+                                  { _, _, c in monad.pure(c + 1) },
+                                  { _, _, _, d in monad.pure(d + 1) },
+                                  { _, _, _, _, e in monad.pure(e + 1) },
+                                  { _, _, _, _, _, f in monad.pure(f + 1) })
+            return eq.eqv(x, monad.pure(a + 6))
+        }
+        
+        property("Monad comprehensions") <- forAll { (a : Int) in
+            let x = monad.binding({ monad.pure(a) },
+                                  { a in monad.pure(a + 1) },
+                                  { _, b in monad.pure(b + 1) },
+                                  { _, _, c in monad.pure(c + 1) },
+                                  { _, _, _, d in monad.pure(d + 1) },
+                                  { _, _, _, _, e in monad.pure(e + 1) },
+                                  { _, _, _, _, _, f in monad.pure(f + 1) },
+                                  { _, _, _, _, _, _, g in monad.pure(g + 1) })
+            return eq.eqv(x, monad.pure(a + 7))
+        }
+        
+        property("Monad comprehensions") <- forAll { (a : Int) in
+            let x = monad.binding({ monad.pure(a) },
+                                  { a in monad.pure(a + 1) },
+                                  { _, b in monad.pure(b + 1) },
+                                  { _, _, c in monad.pure(c + 1) },
+                                  { _, _, _, d in monad.pure(d + 1) },
+                                  { _, _, _, _, e in monad.pure(e + 1) },
+                                  { _, _, _, _, _, f in monad.pure(f + 1) },
+                                  { _, _, _, _, _, _, g in monad.pure(g + 1) },
+                                  { _, _, _, _, _, _, _, h in monad.pure(h + 1) })
+            return eq.eqv(x, monad.pure(a + 8))
+        }
+    }
+    
+    private static func flatten<Mon, EqF>(_ monad : Mon, _ eq : EqF) where Mon : Monad, Mon.F == F, EqF : Eq, EqF.A == Kind<F, Int> {
+        property("Flatten") <- forAll { (a : Int) in
+            return eq.eqv(monad.flatten(monad.pure(monad.pure(a))),
+                          monad.pure(a))
         }
     }
 }

--- a/Tests/BowTests/Typeclasses/OrderLaws.swift
+++ b/Tests/BowTests/Typeclasses/OrderLaws.swift
@@ -20,6 +20,8 @@ class OrderLaws<F, A> where A : Arbitrary {
         antireflexivityOfGreaterThan(order, generator)
         asymmetryOfGreaterThan(order, generator)
         transitivityOfGreaterThan(order, generator)
+        
+        sortConsistentWithMaxMin(order, generator)
     }
     
     private static func reflexivityOfLessThanOrEqual<Ord>(_ order : Ord, _ generator : @escaping (A) -> F) where Ord : Order, Ord.A == F {
@@ -122,4 +124,12 @@ class OrderLaws<F, A> where A : Arbitrary {
         }
     }
     
+    private static func sortConsistentWithMaxMin<Ord>(_ order : Ord, _ generator : @escaping (A) -> F) where Ord : Order, Ord.A == F {
+        property("Sort is consistent with max and min") <- forAll { (a : A, b : A) in
+            let x = generator(a)
+            let y = generator(b)
+            let sorted = order.sort(x, y)
+            return order.eqv(sorted.0, order.max(x, y)) && order.eqv(sorted.1, order.min(x, y))
+        }
+    }
 }

--- a/Tests/BowTests/Typeclasses/TraverseFilterLaws.swift
+++ b/Tests/BowTests/Typeclasses/TraverseFilterLaws.swift
@@ -1,0 +1,26 @@
+import SwiftCheck
+@testable import Bow
+
+class TraverseFilterLaws<F> {
+    static func check<TravFilt, Appl, EqA>(traverseFilter : TravFilt, applicative : Appl, eq : EqA) where TravFilt : TraverseFilter, TravFilt.F == F, Appl : Applicative, Appl.F == F, EqA : Eq, EqA.A == Kind<F, Kind<F, Int>> {
+        identityTraverseFilter(traverseFilter, applicative, eq)
+        filterAConsistentWithTraverseFilter(traverseFilter, applicative, eq)
+    }
+    
+    private static func identityTraverseFilter<TravFilt, Appl, EqA>(_ traverseFilter : TravFilt, _ applicative : Appl, _ eq : EqA) where TravFilt : TraverseFilter, TravFilt.F == F, Appl : Applicative, Appl.F == F, EqA : Eq, EqA.A == Kind<F, Kind<F, Int>> {
+        property("identity traverse filter") <- forAll { (x : Int) in
+            let input = applicative.pure(x)
+            return eq.eqv(traverseFilter.traverseFilter(input, { a in applicative.pure(Maybe<Int>.some(a)) }, applicative),
+                          applicative.pure(input))
+        }
+    }
+    
+    private static func filterAConsistentWithTraverseFilter<TravFilt, Appl, EqA>(_ traverseFilter : TravFilt, _ applicative : Appl, _ eq : EqA) where TravFilt : TraverseFilter, TravFilt.F == F, Appl : Applicative, Appl.F == F, EqA : Eq, EqA.A == Kind<F, Kind<F, Int>> {
+        property("filterA consistent with traverseFilter") <- forAll { (x : Int, bool : Bool) in
+            let input = applicative.pure(x)
+            let f = { (_ : Int) in applicative.pure(bool) }
+            return eq.eqv(traverseFilter.filterA(input, f, applicative),
+                          traverseFilter.traverseFilter(input, { a in applicative.map(f(a)){ b in b ? Maybe<Int>.some(a) : Maybe<Int>.none()} }, applicative))
+        }
+    }
+}

--- a/Tests/BowTests/Typeclasses/TraverseLaws.swift
+++ b/Tests/BowTests/Typeclasses/TraverseLaws.swift
@@ -4,7 +4,6 @@ import SwiftCheck
 class TraverseLaws<F> {
     static func check<Trav, Func, EqA>(traverse : Trav, functor : Func, generator : @escaping (Int) -> Kind<F, Int>, eq : EqA) where Trav : Traverse, Trav.F == F, Func : Functor, Func.F == F,  EqA : Eq, EqA.A == Kind<F, Int> {
         identityTraverse(traverse, functor, generator, eq)
-        foldMapDerived(traverse, generator, eq)
     }
     
     private static func identityTraverse<Trav, Func, EqA>(_ traverse : Trav, _ functor : Func, _ generator : @escaping (Int) -> Kind<F, Int>, _ eq : EqA) where Trav : Traverse, Trav.F == F, Func : Functor, Func.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
@@ -13,14 +12,6 @@ class TraverseLaws<F> {
             let fa = generator(x)
             return eq.eqv(traverse.traverse(fa, f, Id<Int>.applicative()).fix().value,
                           functor.map(functor.map(fa, f), { a in a.fix().value }))
-        }
-    }
-    
-    private static func foldMapDerived<Trav, EqA>(_ traverse : Trav, _ generator : @escaping (Int) -> Kind<F, Int>, _ eq : EqA) where Trav : Traverse, Trav.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
-        property("foldMap derived") <- forAll { (x : Int, f : ArrowOf<Int, Int>) in
-            let traversed = Const.fix(traverse.traverse(generator(x), { a in Const<Int, Int>(a) }, Const<Int, Int>.applicative(Int.sumMonoid))).value
-            let mapped = traverse.foldMap(Int.sumMonoid, generator(x), f.getArrow)
-            return traversed == mapped
         }
     }
 }

--- a/Tests/BowTests/Typeclasses/TraverseLaws.swift
+++ b/Tests/BowTests/Typeclasses/TraverseLaws.swift
@@ -1,0 +1,26 @@
+import SwiftCheck
+@testable import Bow
+
+class TraverseLaws<F> {
+    static func check<Trav, Func, EqA>(traverse : Trav, functor : Func, generator : @escaping (Int) -> Kind<F, Int>, eq : EqA) where Trav : Traverse, Trav.F == F, Func : Functor, Func.F == F,  EqA : Eq, EqA.A == Kind<F, Int> {
+        identityTraverse(traverse, functor, generator, eq)
+        foldMapDerived(traverse, generator, eq)
+    }
+    
+    private static func identityTraverse<Trav, Func, EqA>(_ traverse : Trav, _ functor : Func, _ generator : @escaping (Int) -> Kind<F, Int>, _ eq : EqA) where Trav : Traverse, Trav.F == F, Func : Functor, Func.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
+        property("Identity traverse") <- forAll { (x : Int, y : Int) in
+            let f : (Int) -> Kind<ForId, Int> = { _ in Id<Int>(y) }
+            let fa = generator(x)
+            return eq.eqv(traverse.traverse(fa, f, Id<Int>.applicative()).fix().value,
+                          functor.map(functor.map(fa, f), { a in a.fix().value }))
+        }
+    }
+    
+    private static func foldMapDerived<Trav, EqA>(_ traverse : Trav, _ generator : @escaping (Int) -> Kind<F, Int>, _ eq : EqA) where Trav : Traverse, Trav.F == F, EqA : Eq, EqA.A == Kind<F, Int> {
+        property("foldMap derived") <- forAll { (x : Int, f : ArrowOf<Int, Int>) in
+            let traversed = Const.fix(traverse.traverse(generator(x), { a in Const<Int, Int>(a) }, Const<Int, Int>.applicative(Int.sumMonoid))).value
+            let mapped = traverse.foldMap(Int.sumMonoid, generator(x), f.getArrow)
+            return traversed == mapped
+        }
+    }
+}


### PR DESCRIPTION
This PR aims to improve the test coverage of the library:

- Adds `FoldableLaws`, `TraverseLaws` and `TraverseFilterLaws`, and tests these laws for each instance in the library
- Tests missing laws for some instances.
- Tests core properties for the most used datatypes.
