### PR TITLE
Make data types conform to Equatable

### DIFF
--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -166,3 +166,9 @@ public class ConstEq<R, S, EqR> : Eq where EqR : Eq, EqR.A == R {
         return eqr.eqv(Const.fix(a).value, Const.fix(b).value)
     }
 }
+
+extension Const : Equatable where A : Equatable {
+    public static func ==(lhs : Const<A, T>, rhs : Const<A, T>) -> Bool {
+        return lhs.value == rhs.value
+    }
+}

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -239,3 +239,10 @@ public class EitherEq<L, R, EqL, EqR> : Eq where EqL : Eq, EqL.A == L, EqR : Eq,
                                  { aRight in Either.fix(b).fold(constant(false), { bRight in eqr.eqv(aRight, bRight) }) })
     }
 }
+
+extension Either : Equatable where A : Equatable, B : Equatable {
+    public static func ==(lhs : Either<A, B>, rhs : Either<A, B>) -> Bool {
+        return lhs.fold({ la in rhs.fold({ lb in la == lb }, constant(false)) },
+                        { ra in rhs.fold(constant(false), { rb in ra == rb })})
+    }
+}

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -172,3 +172,9 @@ public class IdEq<B, EqB> : Eq where EqB : Eq, EqB.A == B {
         return eqb.eqv(Id.fix(a).value, Id.fix(b).value)
     }
 }
+
+extension Id : Equatable where A : Equatable {
+    public static func ==(lhs : Id<A>, rhs : Id<A>) -> Bool {
+        return lhs.value == rhs.value
+    }
+}

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -302,5 +302,10 @@ public class IorEq<L, R, EqL, EqR> : Eq where EqL : Eq, EqL.A == L, EqR : Eq, Eq
     }
 }
 
-
-
+extension Ior : Equatable where A : Equatable, B : Equatable {
+    public static func ==(lhs : Ior<A, B>, rhs : Ior<A, B>) -> Bool {
+        return lhs.fold({ la in rhs.fold({ ra in la == ra }, constant(false), constant(false)) },
+                        { lb in rhs.fold(constant(false), { rb in lb == rb }, constant(false)) },
+                        { la, lb in rhs.fold(constant(false), constant(false), { ra, rb in la == ra && lb == rb })})
+    }
+}

--- a/Sources/Bow/Data/ListK.swift
+++ b/Sources/Bow/Data/ListK.swift
@@ -299,4 +299,8 @@ public class ListKEq<R, EqR> : Eq where EqR : Eq, EqR.A == R {
     }
 }
 
-
+extension ListK : Equatable where A : Equatable {
+    public static func ==(lhs : ListK<A>, rhs : ListK<A>) -> Bool {
+        return lhs.list == rhs.list
+    }
+}

--- a/Sources/Bow/Data/Maybe.swift
+++ b/Sources/Bow/Data/Maybe.swift
@@ -325,3 +325,10 @@ public class MaybeTraverseFilter : MaybeTraverse, TraverseFilter {
         return fa.fix().traverseFilter(f, applicative)
     }
 }
+
+extension Maybe : Equatable where A : Equatable {
+    public static func ==(lhs : Maybe<A>, rhs : Maybe<A>) -> Bool {
+        return lhs.fold({ rhs.fold(constant(true), constant(false)) },
+                        { a in rhs.fold(constant(false), { b in a == b })})
+    }
+}

--- a/Sources/Bow/Data/NonEmptyList.swift
+++ b/Sources/Bow/Data/NonEmptyList.swift
@@ -287,3 +287,9 @@ public class NonEmptyListEq<R, EqR> : Eq where EqR : Eq, EqR.A == R {
         }
     }
 }
+
+extension NonEmptyList : Equatable where A : Equatable {
+    public static func ==(lhs : Nel<A>, rhs : Nel<A>) -> Bool {
+        return lhs.all() == rhs.all()
+    }
+}

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -251,3 +251,10 @@ public class TryTraverse : TryFoldable, Traverse {
         return fa.fix().traverse(f, applicative)
     }
 }
+
+extension Try : Equatable where A : Equatable {
+    public static func ==(lhs : Try<A>, rhs : Try<A>) -> Bool {
+        return lhs.fold({ aError in rhs.fold({ bError in "\(aError)" == "\(bError)"}, constant(false))},
+                        { a in rhs.fold(constant(false), { b in a == b }) })
+    }
+}

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -276,3 +276,10 @@ public class ValidatedEq<L, R, EqL, EqR> : Eq where EqL : Eq, EqL.A == L, EqR : 
                       { aValid in b.fold(constant(false), { bValid in eqr.eqv(aValid, bValid) })})
     }
 }
+
+extension Validated : Equatable where E : Equatable, A : Equatable {
+    public static func ==(lhs : Validated<E, A>, rhs : Validated<E, A>) -> Bool {
+        return lhs.fold({ le in rhs.fold({ re in le == re }, constant(false)) },
+                        { la in rhs.fold(constant(false), { ra in la == ra }) })
+    }
+}


### PR DESCRIPTION
This PR adds conformance to Equatable to the following data types:

- `Const`
- `Either`
- `Id`
- `Ior`
- `ListK`
- `Maybe`
- `NonEmptyList`
- `Try`
- `Validated`