### PR TITLE
Conformance to CustomDebugStringConvertible

### DIFF
--- a/Sources/Bow/Data/Const.swift
+++ b/Sources/Bow/Data/Const.swift
@@ -46,6 +46,12 @@ extension Const : CustomStringConvertible {
     }
 }
 
+extension Const : CustomDebugStringConvertible where A : CustomDebugStringConvertible{
+    public var debugDescription: String {
+        return "Const(\(value.debugDescription))"
+    }
+}
+
 public extension Const {
     public static func functor() -> ConstFunctor<A> {
         return ConstFunctor<A>()

--- a/Sources/Bow/Data/Either.swift
+++ b/Sources/Bow/Data/Either.swift
@@ -130,6 +130,13 @@ extension Either : CustomStringConvertible {
     }
 }
 
+extension Either : CustomDebugStringConvertible where A : CustomDebugStringConvertible, B : CustomDebugStringConvertible {
+    public var debugDescription : String {
+        return fold({ a in "Left(\(a.debugDescription)"},
+                    { b in "Right(\(b.debugDescription))"})
+    }
+}
+
 public extension Either {
     public static func functor() -> EitherApplicative<A> {
         return EitherApplicative<A>()

--- a/Sources/Bow/Data/Id.swift
+++ b/Sources/Bow/Data/Id.swift
@@ -69,6 +69,12 @@ extension Id : CustomStringConvertible {
     }
 }
 
+extension Id : CustomDebugStringConvertible where A : CustomDebugStringConvertible {
+    public var debugDescription : String {
+        return "Id(\(value.debugDescription))"
+    }
+}
+
 extension Id {
     public static func functor() -> IdFunctor {
         return IdFunctor()

--- a/Sources/Bow/Data/Ior.swift
+++ b/Sources/Bow/Data/Ior.swift
@@ -197,6 +197,14 @@ extension Ior : CustomStringConvertible {
     }
 }
 
+extension Ior : CustomDebugStringConvertible where A : CustomDebugStringConvertible, B : CustomDebugStringConvertible {
+    public var debugDescription : String {
+        return fold({ a in "Left(\(a.debugDescription))" },
+                    { b in "Right(\(b.debugDescription))" },
+                    { a, b in "Both(\(a.debugDescription), \(b.debugDescription))" })
+    }
+}
+
 public extension Ior {
     public static func functor() -> IorFunctor<A> {
         return IorFunctor<A>()

--- a/Sources/Bow/Data/ListK.swift
+++ b/Sources/Bow/Data/ListK.swift
@@ -125,6 +125,20 @@ public extension Array {
     }
 }
 
+extension ListK : CustomStringConvertible {
+    public var description : String {
+        let contentsString = self.list.map { x in "\(x)" }.joined(separator: ", ")
+        return "ListK(\(contentsString))"
+    }
+}
+
+extension ListK : CustomDebugStringConvertible where A : CustomDebugStringConvertible {
+    public var debugDescription : String {
+        let contentsString = self.list.map { x in x.debugDescription }.joined(separator: ", ")
+        return "ListK(\(contentsString))"
+    }
+}
+
 public extension ListK {
     public static func functor() -> ListKFunctor {
         return ListKFunctor()

--- a/Sources/Bow/Data/Maybe.swift
+++ b/Sources/Bow/Data/Maybe.swift
@@ -149,6 +149,13 @@ extension Maybe : CustomStringConvertible {
     }
 }
 
+extension Maybe : CustomDebugStringConvertible where A : CustomDebugStringConvertible {
+    public var debugDescription : String {
+        return fold(constant("None"),
+                    { a in "Some(\(a.debugDescription)" })
+    }
+}
+
 public extension Kind where F == ForMaybe {
     public func fix() -> Maybe<A> {
         return self as! Maybe<A>

--- a/Sources/Bow/Data/NonEmptyList.swift
+++ b/Sources/Bow/Data/NonEmptyList.swift
@@ -146,6 +146,13 @@ extension NonEmptyList : CustomStringConvertible {
     }
 }
 
+extension NonEmptyList : CustomDebugStringConvertible where A : CustomDebugStringConvertible {
+    public var debugDescription : String {
+        let contentsString = self.all().map { x in x.debugDescription }.joined(separator: ", ")
+        return "NonEmptyList(\(contentsString))"
+    }
+}
+
 public extension Kind where F == ForNonEmptyList {
     public func fix() -> NonEmptyList<A> {
         return self as! NonEmptyList<A>

--- a/Sources/Bow/Data/Try.swift
+++ b/Sources/Bow/Data/Try.swift
@@ -142,6 +142,13 @@ extension Try : CustomStringConvertible {
     }
 }
 
+extension Try : CustomDebugStringConvertible where A : CustomDebugStringConvertible {
+    public var debugDescription : String {
+        return fold({ error in "Failure(\(error))" },
+                    { value in "Success(\(value.debugDescription))" })
+    }
+}
+
 public extension Kind where F == ForTry {
     public func fix() -> Try<A> {
         return self as! Try<A>

--- a/Sources/Bow/Data/Validated.swift
+++ b/Sources/Bow/Data/Validated.swift
@@ -161,6 +161,13 @@ extension Validated : CustomStringConvertible {
     }
 }
 
+extension Validated : CustomDebugStringConvertible where E : CustomDebugStringConvertible, A : CustomDebugStringConvertible {
+    public var debugDescription : String {
+        return fold({ error in "Invalid(\(error.debugDescription))" },
+                    { value in "Valid(\(value.debugDescription))" })
+    }
+}
+
 public extension Validated {
     public static func functor() -> ValidatedFunctor<E> {
         return ValidatedFunctor<E>()


### PR DESCRIPTION
This PR adds conformance to `CustomDebugStringConvertible` to the following data types:

- `Const`
- `Either`
- `Id`
- `Ior`
- `ListK`
- `Maybe`
- `NonEmptyList`
- `Try`
- `Validated`

Conformance to this protocol provides an easier understanding of the contents of a data type when debugging it.