### PR TITLE
Make travis build all four targets to make sure no file is missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 language: objective-c
-osx_image: xcode9.3
+osx_image: xcode9.4
 env:
+  global:
+    - PROJECT=Bow.xcodeproj
   secure: LatJH8j809/6dhEO6WhpQyU3lAjtkOYHAqWD14+bU6lfAc5oRrRFO4B7h56gnIDu6tvYJS0Qa/IhIuB3zZQ/GlG12oivgE/FKp1xXxxHwqjmhPHdetX9YkeAbicJ8YrSQ+C0UC6NMmP1WtU7cmLBV4Q1VwdPnVvRIrOVuWdh3ITUzUz/qQMTZwi+6Z1w92QvxbyytXDqti62NrUq81ba2c7pvBbFBujMp5hyd6+EcuZojYWGNN3cIR2DcPVXD9j4kwLyDPVAcN/OROAwaJlOZ63FbsoUcZULOAX/6s5bmcU1CuYc+eBrXX7KifSqj3yUW00Ea0ynyvsn2GWldAw5b8cYgiLuqQBp3jxtPVH/tEWRdO5TdFtMl8CDEJQiblINjFCXRbnAh8fnk/9jxKTkK+e1DXNQEk/w61+vUB21j74Zw8PhPRvCsoV8XgPkd34UiSlG5XkPaj+vImRpB2/kemYxynpY2Sjq+qoK4iUJy/DXhX/agThWCpjY1hWL2LNL/24mk6DbUHZGVH+4RgoBJxBFCI7ucSp14Og0cCFmhFfsq0nttN+xNegosmHnEcv1Z4tRW750rPf2dgGlXkf6s4msbZ/kyRnccs2zlh3JYYac509Fk98FRNfLb9q0C/jLb0xpg6qf9WbI1QbMcxPHKakyGEUuo+7FO+CLzrJ0qns=
+matrix:
+  include:
+    - env: JOB="XCODE" DEST="OS=11.4,name=iPhone 8 Plus" SCHEME="Bow" SDK="iphonesimulator" ACTION="test"
+    - env: JOB="XCODE" DEST="arch=x86_64" SCHEME="Bow-macOS" SDK="macosx" ACTION="test"
+    - env: JOB="XCODE" DEST="OS=11.4,name=Apple TV" SCHEME="Bow-tvOS" SDK="appletvsimulator" ACTION="test"
+    - env: JOB="XCODE" DEST="OS=4.3,name=Apple Watch - 42mm" SCHEME="Bow-watchOS" SDK="watchsimulator" ACTION="build"
+
 before_install:
   - carthage bootstrap
 
 script:
   - set -o pipefail
-  - xcodebuild test -project Bow.xcodeproj -scheme Bow -sdk iphonesimulator ONLY_ACTIVE_ARCH=NO -destination "platform=iOS Simulator,OS=11.3,name=iPhone X" | xcpretty -c
+  - xcodebuild "$ACTION" -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" ONLY_ACTIVE_ARCH=NO -destination "$DEST" | xcpretty -c
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -94,6 +94,9 @@
 		11635BBA20F77FE5007BB4FA /* TraverseFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */; };
 		11635BBB20F77FE5007BB4FA /* TraverseFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */; };
 		11635BBC20F77FE5007BB4FA /* TraverseFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */; };
+		116D42C52110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
+		116D42C62110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
+		116D42C72110A66600363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		11AA440F2088D4080091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AA44102088D4090091B474 /* ShowLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 111082D02085DD4D00C8563C /* ShowLaws.swift */; };
 		11AC527320974D58008EC1E4 /* Getter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AC527220974D58008EC1E4 /* Getter.swift */; };
@@ -1769,6 +1772,7 @@
 				11E531CC209B319E00A78E8D /* MaybeInstances.swift in Sources */,
 				D6D624FC2068178800739E2D /* Alternative.swift in Sources */,
 				D6D624FD2068178800739E2D /* Applicative.swift in Sources */,
+				116D42C52110A66500363A86 /* BoolInstances.swift in Sources */,
 				D6D624FE2068178800739E2D /* ApplicativeError.swift in Sources */,
 				11C9B6D120DCF54600AFD4AA /* Each.swift in Sources */,
 				D6D624FF2068178800739E2D /* Bifoldable.swift in Sources */,
@@ -1954,6 +1958,7 @@
 				11E531CD209B319F00A78E8D /* MaybeInstances.swift in Sources */,
 				D6D6258D206841B300739E2D /* Alternative.swift in Sources */,
 				D6D6258E206841B300739E2D /* Applicative.swift in Sources */,
+				116D42C62110A66500363A86 /* BoolInstances.swift in Sources */,
 				D6D6258F206841B300739E2D /* ApplicativeError.swift in Sources */,
 				11C9B6D220DCF54700AFD4AA /* Each.swift in Sources */,
 				D6D62590206841B300739E2D /* Bifoldable.swift in Sources */,
@@ -2063,6 +2068,7 @@
 				11E531CE209B31A000A78E8D /* MaybeInstances.swift in Sources */,
 				D6DBDEC320684C38004F979F /* Alternative.swift in Sources */,
 				D6DBDEC420684C38004F979F /* Applicative.swift in Sources */,
+				116D42C72110A66600363A86 /* BoolInstances.swift in Sources */,
 				D6DBDEC520684C38004F979F /* ApplicativeError.swift in Sources */,
 				11C9B6D320DCF54800AFD4AA /* Each.swift in Sources */,
 				D6DBDEC620684C38004F979F /* Bifoldable.swift in Sources */,


### PR DESCRIPTION
The previous Travis configuration was building only the main target (for iOS). With the new configuration, Travis will build additionally the targets for macOS, watchOS and tvOS, making sure all files are included in all targets and preventing issues like #38.