### PR TITLE
Comonadic UIs data types

### DIFF
--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -157,6 +157,9 @@
 		11689028216392EF00F3A7A6 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11689026216392EF00F3A7A6 /* Day.swift */; };
 		11689029216392EF00F3A7A6 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11689026216392EF00F3A7A6 /* Day.swift */; };
 		1168902A216392EF00F3A7A6 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11689026216392EF00F3A7A6 /* Day.swift */; };
+		1168902C2164AAFB00F3A7A6 /* DayTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902B2164AAFB00F3A7A6 /* DayTest.swift */; };
+		1168902D2164AAFB00F3A7A6 /* DayTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902B2164AAFB00F3A7A6 /* DayTest.swift */; };
+		1168902E2164AAFB00F3A7A6 /* DayTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902B2164AAFB00F3A7A6 /* DayTest.swift */; };
 		116D42C52110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C62110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C72110A66600363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
@@ -804,6 +807,7 @@
 		1168901C21638B3D00F3A7A6 /* Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
 		1168902121638D8800F3A7A6 /* Sum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sum.swift; sourceTree = "<group>"; };
 		11689026216392EF00F3A7A6 /* Day.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Day.swift; sourceTree = "<group>"; };
+		1168902B2164AAFB00F3A7A6 /* DayTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayTest.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -1499,13 +1503,14 @@
 			children = (
 				OBJ_97 /* ConstTest.swift */,
 				OBJ_98 /* CoproductTest.swift */,
+				1168902B2164AAFB00F3A7A6 /* DayTest.swift */,
 				OBJ_99 /* EitherTest.swift */,
 				OBJ_100 /* EvalTest.swift */,
 				OBJ_101 /* IdTest.swift */,
 				OBJ_102 /* IorTest.swift */,
 				OBJ_103 /* ListKTest.swift */,
-				OBJ_104 /* OptionTest.swift */,
 				OBJ_105 /* NonEmptyListTest.swift */,
+				OBJ_104 /* OptionTest.swift */,
 				D68DC58B2106653D00D7D845 /* SetKTest.swift */,
 				OBJ_106 /* TryTest.swift */,
 				OBJ_107 /* TupleTest.swift */,
@@ -1758,6 +1763,7 @@
 				D6D624482068141800739E2D /* BooleanFunctionsTest.swift in Sources */,
 				D6D624492068141800739E2D /* CurryTest.swift in Sources */,
 				111620B420F6137B00685EC4 /* BimonadLaws.swift in Sources */,
+				1168902D2164AAFB00F3A7A6 /* DayTest.swift in Sources */,
 				D6D6244A2068141800739E2D /* ConstTest.swift in Sources */,
 				11F53070210086FD00D92335 /* FoldTest.swift in Sources */,
 				115683BB216253E00001749D /* ContravariantLaws.swift in Sources */,
@@ -1961,6 +1967,7 @@
 				D6D62527206817A700739E2D /* BooleanFunctionsTest.swift in Sources */,
 				D6D62528206817A700739E2D /* CurryTest.swift in Sources */,
 				111620B520F6137C00685EC4 /* BimonadLaws.swift in Sources */,
+				1168902E2164AAFB00F3A7A6 /* DayTest.swift in Sources */,
 				D6D62529206817A700739E2D /* ConstTest.swift in Sources */,
 				11F53071210086FE00D92335 /* FoldTest.swift in Sources */,
 				115683BC216253E00001749D /* ContravariantLaws.swift in Sources */,
@@ -2286,6 +2293,7 @@
 				OBJ_250 /* BooleanFunctionsTest.swift in Sources */,
 				OBJ_251 /* CurryTest.swift in Sources */,
 				111620B320F6137B00685EC4 /* BimonadLaws.swift in Sources */,
+				1168902C2164AAFB00F3A7A6 /* DayTest.swift in Sources */,
 				OBJ_252 /* ConstTest.swift in Sources */,
 				11F5306F210086FD00D92335 /* FoldTest.swift in Sources */,
 				115683BA216253E00001749D /* ContravariantLaws.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -149,6 +149,10 @@
 		1168901E21638B3D00F3A7A6 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168901C21638B3D00F3A7A6 /* Store.swift */; };
 		1168901F21638B3D00F3A7A6 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168901C21638B3D00F3A7A6 /* Store.swift */; };
 		1168902021638B3D00F3A7A6 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168901C21638B3D00F3A7A6 /* Store.swift */; };
+		1168902221638D8800F3A7A6 /* Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902121638D8800F3A7A6 /* Sum.swift */; };
+		1168902321638D8800F3A7A6 /* Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902121638D8800F3A7A6 /* Sum.swift */; };
+		1168902421638D8800F3A7A6 /* Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902121638D8800F3A7A6 /* Sum.swift */; };
+		1168902521638D8800F3A7A6 /* Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902121638D8800F3A7A6 /* Sum.swift */; };
 		116D42C52110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C62110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C72110A66600363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
@@ -794,6 +798,7 @@
 		11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseFilterLaws.swift; sourceTree = "<group>"; };
 		116890172163894600F3A7A6 /* Moore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Moore.swift; sourceTree = "<group>"; };
 		1168901C21638B3D00F3A7A6 /* Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
+		1168902121638D8800F3A7A6 /* Sum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sum.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -1277,6 +1282,7 @@
 				D6492805209C72F000B875F9 /* SetK.swift */,
 				OBJ_32 /* State.swift */,
 				1168901C21638B3D00F3A7A6 /* Store.swift */,
+				1168902121638D8800F3A7A6 /* Sum.swift */,
 				OBJ_33 /* Try.swift */,
 				OBJ_34 /* Tuple.swift */,
 				OBJ_35 /* Validated.swift */,
@@ -1886,6 +1892,7 @@
 				D6D624FD2068178800739E2D /* Applicative.swift in Sources */,
 				116D42C52110A66500363A86 /* BoolInstances.swift in Sources */,
 				D6D624FE2068178800739E2D /* ApplicativeError.swift in Sources */,
+				1168902321638D8800F3A7A6 /* Sum.swift in Sources */,
 				11C9B6D120DCF54600AFD4AA /* Each.swift in Sources */,
 				D6D624FF2068178800739E2D /* Bifoldable.swift in Sources */,
 				D6D625002068178800739E2D /* Bimonad.swift in Sources */,
@@ -2087,6 +2094,7 @@
 				D6D6258E206841B300739E2D /* Applicative.swift in Sources */,
 				116D42C62110A66500363A86 /* BoolInstances.swift in Sources */,
 				D6D6258F206841B300739E2D /* ApplicativeError.swift in Sources */,
+				1168902421638D8800F3A7A6 /* Sum.swift in Sources */,
 				11C9B6D220DCF54700AFD4AA /* Each.swift in Sources */,
 				D6D62590206841B300739E2D /* Bifoldable.swift in Sources */,
 				D6D62591206841B300739E2D /* Bimonad.swift in Sources */,
@@ -2207,6 +2215,7 @@
 				D6DBDEC420684C38004F979F /* Applicative.swift in Sources */,
 				116D42C72110A66600363A86 /* BoolInstances.swift in Sources */,
 				D6DBDEC520684C38004F979F /* ApplicativeError.swift in Sources */,
+				1168902521638D8800F3A7A6 /* Sum.swift in Sources */,
 				11C9B6D320DCF54800AFD4AA /* Each.swift in Sources */,
 				D6DBDEC620684C38004F979F /* Bifoldable.swift in Sources */,
 				D6DBDEC720684C38004F979F /* Bimonad.swift in Sources */,
@@ -2408,6 +2417,7 @@
 				OBJ_422 /* Alternative.swift in Sources */,
 				OBJ_423 /* Applicative.swift in Sources */,
 				OBJ_424 /* ApplicativeError.swift in Sources */,
+				1168902221638D8800F3A7A6 /* Sum.swift in Sources */,
 				OBJ_425 /* Bifoldable.swift in Sources */,
 				OBJ_426 /* Bimonad.swift in Sources */,
 				1116208E20F4AB1700685EC4 /* NonEmptyListOpticsInstances.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -160,6 +160,9 @@
 		1168902C2164AAFB00F3A7A6 /* DayTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902B2164AAFB00F3A7A6 /* DayTest.swift */; };
 		1168902D2164AAFB00F3A7A6 /* DayTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902B2164AAFB00F3A7A6 /* DayTest.swift */; };
 		1168902E2164AAFB00F3A7A6 /* DayTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902B2164AAFB00F3A7A6 /* DayTest.swift */; };
+		116890302164B10000F3A7A6 /* MooreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902F2164B10000F3A7A6 /* MooreTest.swift */; };
+		116890312164B10000F3A7A6 /* MooreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902F2164B10000F3A7A6 /* MooreTest.swift */; };
+		116890322164B10000F3A7A6 /* MooreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902F2164B10000F3A7A6 /* MooreTest.swift */; };
 		116D42C52110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C62110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C72110A66600363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
@@ -808,6 +811,7 @@
 		1168902121638D8800F3A7A6 /* Sum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sum.swift; sourceTree = "<group>"; };
 		11689026216392EF00F3A7A6 /* Day.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Day.swift; sourceTree = "<group>"; };
 		1168902B2164AAFB00F3A7A6 /* DayTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayTest.swift; sourceTree = "<group>"; };
+		1168902F2164B10000F3A7A6 /* MooreTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MooreTest.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -1509,6 +1513,7 @@
 				OBJ_101 /* IdTest.swift */,
 				OBJ_102 /* IorTest.swift */,
 				OBJ_103 /* ListKTest.swift */,
+				1168902F2164B10000F3A7A6 /* MooreTest.swift */,
 				OBJ_105 /* NonEmptyListTest.swift */,
 				OBJ_104 /* OptionTest.swift */,
 				D68DC58B2106653D00D7D845 /* SetKTest.swift */,
@@ -1779,6 +1784,7 @@
 				D6D624512068141800739E2D /* OptionTest.swift in Sources */,
 				D6D624522068141800739E2D /* NonEmptyListTest.swift in Sources */,
 				D6D624532068141800739E2D /* TryTest.swift in Sources */,
+				116890312164B10000F3A7A6 /* MooreTest.swift in Sources */,
 				D6D624542068141800739E2D /* TupleTest.swift in Sources */,
 				11FE006B209C5E3A00183AF6 /* LensLaws.swift in Sources */,
 				D6D624552068141800739E2D /* ValidatedTest.swift in Sources */,
@@ -1983,6 +1989,7 @@
 				D6D62530206817A700739E2D /* OptionTest.swift in Sources */,
 				D6D62531206817A700739E2D /* NonEmptyListTest.swift in Sources */,
 				D6D62532206817A700739E2D /* TryTest.swift in Sources */,
+				116890322164B10000F3A7A6 /* MooreTest.swift in Sources */,
 				D6D62533206817A700739E2D /* TupleTest.swift in Sources */,
 				11FE006C209C5E3A00183AF6 /* LensLaws.swift in Sources */,
 				D6D62534206817A700739E2D /* ValidatedTest.swift in Sources */,
@@ -2309,6 +2316,7 @@
 				OBJ_259 /* OptionTest.swift in Sources */,
 				OBJ_260 /* NonEmptyListTest.swift in Sources */,
 				OBJ_261 /* TryTest.swift in Sources */,
+				116890302164B10000F3A7A6 /* MooreTest.swift in Sources */,
 				OBJ_262 /* TupleTest.swift in Sources */,
 				11FE006A209C5E3A00183AF6 /* LensLaws.swift in Sources */,
 				OBJ_263 /* ValidatedTest.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -153,6 +153,10 @@
 		1168902321638D8800F3A7A6 /* Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902121638D8800F3A7A6 /* Sum.swift */; };
 		1168902421638D8800F3A7A6 /* Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902121638D8800F3A7A6 /* Sum.swift */; };
 		1168902521638D8800F3A7A6 /* Sum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902121638D8800F3A7A6 /* Sum.swift */; };
+		11689027216392EF00F3A7A6 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11689026216392EF00F3A7A6 /* Day.swift */; };
+		11689028216392EF00F3A7A6 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11689026216392EF00F3A7A6 /* Day.swift */; };
+		11689029216392EF00F3A7A6 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11689026216392EF00F3A7A6 /* Day.swift */; };
+		1168902A216392EF00F3A7A6 /* Day.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11689026216392EF00F3A7A6 /* Day.swift */; };
 		116D42C52110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C62110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C72110A66600363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
@@ -799,6 +803,7 @@
 		116890172163894600F3A7A6 /* Moore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Moore.swift; sourceTree = "<group>"; };
 		1168901C21638B3D00F3A7A6 /* Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
 		1168902121638D8800F3A7A6 /* Sum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sum.swift; sourceTree = "<group>"; };
+		11689026216392EF00F3A7A6 /* Day.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Day.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -1268,6 +1273,7 @@
 				OBJ_19 /* Const.swift */,
 				OBJ_20 /* Coproduct.swift */,
 				OBJ_21 /* Coreader.swift */,
+				11689026216392EF00F3A7A6 /* Day.swift */,
 				OBJ_22 /* Either.swift */,
 				OBJ_23 /* Eval.swift */,
 				OBJ_24 /* FlatmapOperator.swift */,
@@ -1899,6 +1905,7 @@
 				D6D625012068178800739E2D /* Comonad.swift in Sources */,
 				1116205320F385D300685EC4 /* Either+Optics.swift in Sources */,
 				1116208A20F49B1E00685EC4 /* ListKOpticsInstances.swift in Sources */,
+				11689028216392EF00F3A7A6 /* Day.swift in Sources */,
 				D6D625022068178800739E2D /* Composed.swift in Sources */,
 				D6D625032068178800739E2D /* ComposedFoldable.swift in Sources */,
 				D6D625042068178800739E2D /* Eq.swift in Sources */,
@@ -2101,6 +2108,7 @@
 				D6D62592206841B300739E2D /* Comonad.swift in Sources */,
 				1116205720F385D300685EC4 /* Either+Optics.swift in Sources */,
 				1116208B20F49B1F00685EC4 /* ListKOpticsInstances.swift in Sources */,
+				11689029216392EF00F3A7A6 /* Day.swift in Sources */,
 				D6D62593206841B300739E2D /* Composed.swift in Sources */,
 				D6D62594206841B300739E2D /* ComposedFoldable.swift in Sources */,
 				D6D62595206841B300739E2D /* Eq.swift in Sources */,
@@ -2222,6 +2230,7 @@
 				D6DBDEC820684C38004F979F /* Comonad.swift in Sources */,
 				1116205B20F385D400685EC4 /* Either+Optics.swift in Sources */,
 				1116208C20F49B1F00685EC4 /* ListKOpticsInstances.swift in Sources */,
+				1168902A216392EF00F3A7A6 /* Day.swift in Sources */,
 				D6DBDEC920684C38004F979F /* Composed.swift in Sources */,
 				D6DBDECA20684C38004F979F /* ComposedFoldable.swift in Sources */,
 				D6DBDECB20684C38004F979F /* Eq.swift in Sources */,
@@ -2424,6 +2433,7 @@
 				OBJ_427 /* Comonad.swift in Sources */,
 				1116204620F37AE300685EC4 /* Either+Optics.swift in Sources */,
 				OBJ_428 /* Composed.swift in Sources */,
+				11689027216392EF00F3A7A6 /* Day.swift in Sources */,
 				11E531C5209B29EF00A78E8D /* BoolInstances.swift in Sources */,
 				OBJ_429 /* ComposedFoldable.swift in Sources */,
 				1116206720F39E0700685EC4 /* Validated+Optics.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -166,6 +166,9 @@
 		116890342164B6E300F3A7A6 /* StoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890332164B6E300F3A7A6 /* StoreTest.swift */; };
 		116890352164B6E300F3A7A6 /* StoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890332164B6E300F3A7A6 /* StoreTest.swift */; };
 		116890362164B6E300F3A7A6 /* StoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890332164B6E300F3A7A6 /* StoreTest.swift */; };
+		116890382164BA6D00F3A7A6 /* SumTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890372164BA6D00F3A7A6 /* SumTest.swift */; };
+		116890392164BA6D00F3A7A6 /* SumTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890372164BA6D00F3A7A6 /* SumTest.swift */; };
+		1168903A2164BA6D00F3A7A6 /* SumTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890372164BA6D00F3A7A6 /* SumTest.swift */; };
 		116D42C52110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C62110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C72110A66600363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
@@ -816,6 +819,7 @@
 		1168902B2164AAFB00F3A7A6 /* DayTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayTest.swift; sourceTree = "<group>"; };
 		1168902F2164B10000F3A7A6 /* MooreTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MooreTest.swift; sourceTree = "<group>"; };
 		116890332164B6E300F3A7A6 /* StoreTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreTest.swift; sourceTree = "<group>"; };
+		116890372164BA6D00F3A7A6 /* SumTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SumTest.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -1522,6 +1526,7 @@
 				OBJ_104 /* OptionTest.swift */,
 				D68DC58B2106653D00D7D845 /* SetKTest.swift */,
 				116890332164B6E300F3A7A6 /* StoreTest.swift */,
+				116890372164BA6D00F3A7A6 /* SumTest.swift */,
 				OBJ_106 /* TryTest.swift */,
 				OBJ_107 /* TupleTest.swift */,
 				OBJ_108 /* ValidatedTest.swift */,
@@ -1776,6 +1781,7 @@
 				111620B420F6137B00685EC4 /* BimonadLaws.swift in Sources */,
 				1168902D2164AAFB00F3A7A6 /* DayTest.swift in Sources */,
 				D6D6244A2068141800739E2D /* ConstTest.swift in Sources */,
+				116890392164BA6D00F3A7A6 /* SumTest.swift in Sources */,
 				11F53070210086FD00D92335 /* FoldTest.swift in Sources */,
 				115683BB216253E00001749D /* ContravariantLaws.swift in Sources */,
 				D6D6244B2068141800739E2D /* CoproductTest.swift in Sources */,
@@ -1982,6 +1988,7 @@
 				111620B520F6137C00685EC4 /* BimonadLaws.swift in Sources */,
 				1168902E2164AAFB00F3A7A6 /* DayTest.swift in Sources */,
 				D6D62529206817A700739E2D /* ConstTest.swift in Sources */,
+				1168903A2164BA6D00F3A7A6 /* SumTest.swift in Sources */,
 				11F53071210086FE00D92335 /* FoldTest.swift in Sources */,
 				115683BC216253E00001749D /* ContravariantLaws.swift in Sources */,
 				D6D6252A206817A700739E2D /* CoproductTest.swift in Sources */,
@@ -2310,6 +2317,7 @@
 				111620B320F6137B00685EC4 /* BimonadLaws.swift in Sources */,
 				1168902C2164AAFB00F3A7A6 /* DayTest.swift in Sources */,
 				OBJ_252 /* ConstTest.swift in Sources */,
+				116890382164BA6D00F3A7A6 /* SumTest.swift in Sources */,
 				11F5306F210086FD00D92335 /* FoldTest.swift in Sources */,
 				115683BA216253E00001749D /* ContravariantLaws.swift in Sources */,
 				OBJ_253 /* CoproductTest.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -163,6 +163,9 @@
 		116890302164B10000F3A7A6 /* MooreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902F2164B10000F3A7A6 /* MooreTest.swift */; };
 		116890312164B10000F3A7A6 /* MooreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902F2164B10000F3A7A6 /* MooreTest.swift */; };
 		116890322164B10000F3A7A6 /* MooreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168902F2164B10000F3A7A6 /* MooreTest.swift */; };
+		116890342164B6E300F3A7A6 /* StoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890332164B6E300F3A7A6 /* StoreTest.swift */; };
+		116890352164B6E300F3A7A6 /* StoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890332164B6E300F3A7A6 /* StoreTest.swift */; };
+		116890362164B6E300F3A7A6 /* StoreTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890332164B6E300F3A7A6 /* StoreTest.swift */; };
 		116D42C52110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C62110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C72110A66600363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
@@ -812,6 +815,7 @@
 		11689026216392EF00F3A7A6 /* Day.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Day.swift; sourceTree = "<group>"; };
 		1168902B2164AAFB00F3A7A6 /* DayTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayTest.swift; sourceTree = "<group>"; };
 		1168902F2164B10000F3A7A6 /* MooreTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MooreTest.swift; sourceTree = "<group>"; };
+		116890332164B6E300F3A7A6 /* StoreTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreTest.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -1517,6 +1521,7 @@
 				OBJ_105 /* NonEmptyListTest.swift */,
 				OBJ_104 /* OptionTest.swift */,
 				D68DC58B2106653D00D7D845 /* SetKTest.swift */,
+				116890332164B6E300F3A7A6 /* StoreTest.swift */,
 				OBJ_106 /* TryTest.swift */,
 				OBJ_107 /* TupleTest.swift */,
 				OBJ_108 /* ValidatedTest.swift */,
@@ -1760,6 +1765,7 @@
 				D6D624452068141800739E2D /* Function1Test.swift in Sources */,
 				11F530742100959000D92335 /* TraversalTest.swift in Sources */,
 				115683C321625D550001749D /* BifunctorLaws.swift in Sources */,
+				116890352164B6E300F3A7A6 /* StoreTest.swift in Sources */,
 				11FE008A209C98A400183AF6 /* SetterTest.swift in Sources */,
 				D6D624462068141800739E2D /* KleisliOperatorTest.swift in Sources */,
 				11FE006F209C685F00183AF6 /* SetterLaws.swift in Sources */,
@@ -1965,6 +1971,7 @@
 				D6D62524206817A700739E2D /* Function1Test.swift in Sources */,
 				11F530752100959000D92335 /* TraversalTest.swift in Sources */,
 				115683C421625D550001749D /* BifunctorLaws.swift in Sources */,
+				116890362164B6E300F3A7A6 /* StoreTest.swift in Sources */,
 				11FE008B209C98A400183AF6 /* SetterTest.swift in Sources */,
 				D6D62525206817A700739E2D /* KleisliOperatorTest.swift in Sources */,
 				11FE0070209C685F00183AF6 /* SetterLaws.swift in Sources */,
@@ -2292,6 +2299,7 @@
 				OBJ_247 /* Function1Test.swift in Sources */,
 				11F530732100959000D92335 /* TraversalTest.swift in Sources */,
 				115683C221625D550001749D /* BifunctorLaws.swift in Sources */,
+				116890342164B6E300F3A7A6 /* StoreTest.swift in Sources */,
 				11FE0089209C98A400183AF6 /* SetterTest.swift in Sources */,
 				OBJ_248 /* KleisliOperatorTest.swift in Sources */,
 				11FE006E209C685F00183AF6 /* SetterLaws.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -141,6 +141,10 @@
 		11635BBA20F77FE5007BB4FA /* TraverseFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */; };
 		11635BBB20F77FE5007BB4FA /* TraverseFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */; };
 		11635BBC20F77FE5007BB4FA /* TraverseFilterLaws.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */; };
+		116890182163894600F3A7A6 /* Moore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890172163894600F3A7A6 /* Moore.swift */; };
+		116890192163894600F3A7A6 /* Moore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890172163894600F3A7A6 /* Moore.swift */; };
+		1168901A2163894600F3A7A6 /* Moore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890172163894600F3A7A6 /* Moore.swift */; };
+		1168901B2163894600F3A7A6 /* Moore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890172163894600F3A7A6 /* Moore.swift */; };
 		116D42C52110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C62110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C72110A66600363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
@@ -784,6 +788,7 @@
 		11635BB120F64A20007BB4FA /* MonadCombineLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MonadCombineLaws.swift; sourceTree = "<group>"; };
 		11635BB520F76131007BB4FA /* TraverseLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseLaws.swift; sourceTree = "<group>"; };
 		11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseFilterLaws.swift; sourceTree = "<group>"; };
+		116890172163894600F3A7A6 /* Moore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Moore.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -1260,8 +1265,9 @@
 				OBJ_26 /* Ior.swift */,
 				OBJ_27 /* ListK.swift */,
 				OBJ_28 /* MapK.swift */,
-				OBJ_29 /* Option.swift */,
+				116890172163894600F3A7A6 /* Moore.swift */,
 				OBJ_30 /* NonEmptyList.swift */,
+				OBJ_29 /* Option.swift */,
 				OBJ_31 /* Reader.swift */,
 				D6492805209C72F000B875F9 /* SetK.swift */,
 				OBJ_32 /* State.swift */,
@@ -1859,6 +1865,7 @@
 				11AC52792097697C008EC1E4 /* Iso.swift in Sources */,
 				11E531B2209AF13600A78E8D /* Prism.swift in Sources */,
 				D6D624F62068178800739E2D /* Predef.swift in Sources */,
+				116890192163894600F3A7A6 /* Moore.swift in Sources */,
 				D6D624F72068178800739E2D /* EitherT.swift in Sources */,
 				1116205620F385D300685EC4 /* NonEmptyList+Optics.swift in Sources */,
 				115683AD21624C370001749D /* Profunctor.swift in Sources */,
@@ -2058,6 +2065,7 @@
 				11AC527C2097697C008EC1E4 /* Iso.swift in Sources */,
 				11E531B3209AF13600A78E8D /* Prism.swift in Sources */,
 				D6D62587206841B300739E2D /* Predef.swift in Sources */,
+				1168901A2163894600F3A7A6 /* Moore.swift in Sources */,
 				D6D62588206841B300739E2D /* EitherT.swift in Sources */,
 				1116205A20F385D300685EC4 /* NonEmptyList+Optics.swift in Sources */,
 				115683AE21624C370001749D /* Profunctor.swift in Sources */,
@@ -2176,6 +2184,7 @@
 				11AC527F2097697D008EC1E4 /* Iso.swift in Sources */,
 				11E531B4209AF13700A78E8D /* Prism.swift in Sources */,
 				D6DBDEBD20684C38004F979F /* Predef.swift in Sources */,
+				1168901B2163894600F3A7A6 /* Moore.swift in Sources */,
 				D6DBDEBE20684C38004F979F /* EitherT.swift in Sources */,
 				1116205E20F385D400685EC4 /* NonEmptyList+Optics.swift in Sources */,
 				115683AF21624C370001749D /* Profunctor.swift in Sources */,
@@ -2375,6 +2384,7 @@
 				11AC527520975422008EC1E4 /* Iso.swift in Sources */,
 				11C9B6B320DBB0EC00AFD4AA /* FilterIndex.swift in Sources */,
 				11E531B1209AE89A00A78E8D /* Prism.swift in Sources */,
+				116890182163894600F3A7A6 /* Moore.swift in Sources */,
 				1116204C20F380E300685EC4 /* NonEmptyList+Optics.swift in Sources */,
 				OBJ_416 /* Predef.swift in Sources */,
 				115683AC21624C370001749D /* Profunctor.swift in Sources */,

--- a/Bow.xcodeproj/project.pbxproj
+++ b/Bow.xcodeproj/project.pbxproj
@@ -145,6 +145,10 @@
 		116890192163894600F3A7A6 /* Moore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890172163894600F3A7A6 /* Moore.swift */; };
 		1168901A2163894600F3A7A6 /* Moore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890172163894600F3A7A6 /* Moore.swift */; };
 		1168901B2163894600F3A7A6 /* Moore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 116890172163894600F3A7A6 /* Moore.swift */; };
+		1168901D21638B3D00F3A7A6 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168901C21638B3D00F3A7A6 /* Store.swift */; };
+		1168901E21638B3D00F3A7A6 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168901C21638B3D00F3A7A6 /* Store.swift */; };
+		1168901F21638B3D00F3A7A6 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168901C21638B3D00F3A7A6 /* Store.swift */; };
+		1168902021638B3D00F3A7A6 /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1168901C21638B3D00F3A7A6 /* Store.swift */; };
 		116D42C52110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C62110A66500363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
 		116D42C72110A66600363A86 /* BoolInstances.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11E531C4209B29EF00A78E8D /* BoolInstances.swift */; };
@@ -789,6 +793,7 @@
 		11635BB520F76131007BB4FA /* TraverseLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseLaws.swift; sourceTree = "<group>"; };
 		11635BB920F77FE5007BB4FA /* TraverseFilterLaws.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraverseFilterLaws.swift; sourceTree = "<group>"; };
 		116890172163894600F3A7A6 /* Moore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Moore.swift; sourceTree = "<group>"; };
+		1168901C21638B3D00F3A7A6 /* Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
 		11AC527220974D58008EC1E4 /* Getter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Getter.swift; sourceTree = "<group>"; };
 		11AC527420975422008EC1E4 /* Iso.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
 		11AC527620975EE5008EC1E4 /* Lens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; };
@@ -1271,6 +1276,7 @@
 				OBJ_31 /* Reader.swift */,
 				D6492805209C72F000B875F9 /* SetK.swift */,
 				OBJ_32 /* State.swift */,
+				1168901C21638B3D00F3A7A6 /* Store.swift */,
 				OBJ_33 /* Try.swift */,
 				OBJ_34 /* Tuple.swift */,
 				OBJ_35 /* Validated.swift */,
@@ -1821,6 +1827,7 @@
 				D6D624D82068178800739E2D /* KleisliOperator.swift in Sources */,
 				D6D624D92068178800739E2D /* BooleanFunctions.swift in Sources */,
 				1116208F20F4AB6200685EC4 /* NonEmptyListOpticsInstances.swift in Sources */,
+				1168901E21638B3D00F3A7A6 /* Store.swift in Sources */,
 				D6D624DA2068178800739E2D /* Curry.swift in Sources */,
 				11E531D8209B4FCD00A78E8D /* At.swift in Sources */,
 				1156839E2162472C0001749D /* Invariant.swift in Sources */,
@@ -2021,6 +2028,7 @@
 				D6D62569206841B300739E2D /* KleisliOperator.swift in Sources */,
 				D6D6256A206841B300739E2D /* BooleanFunctions.swift in Sources */,
 				1116209020F4AB6200685EC4 /* NonEmptyListOpticsInstances.swift in Sources */,
+				1168901F21638B3D00F3A7A6 /* Store.swift in Sources */,
 				D6D6256B206841B300739E2D /* Curry.swift in Sources */,
 				11E531D9209B4FCD00A78E8D /* At.swift in Sources */,
 				1156839F2162472C0001749D /* Invariant.swift in Sources */,
@@ -2140,6 +2148,7 @@
 				D6DBDE9F20684C38004F979F /* KleisliOperator.swift in Sources */,
 				D6DBDEA020684C38004F979F /* BooleanFunctions.swift in Sources */,
 				1116209120F4AB6300685EC4 /* NonEmptyListOpticsInstances.swift in Sources */,
+				1168902021638B3D00F3A7A6 /* Store.swift in Sources */,
 				D6DBDEA120684C38004F979F /* Curry.swift in Sources */,
 				11E531DA209B4FCE00A78E8D /* At.swift in Sources */,
 				115683A02162472D0001749D /* Invariant.swift in Sources */,
@@ -2340,6 +2349,7 @@
 				1116209D20F4B88500685EC4 /* TryOpticsInstances.swift in Sources */,
 				OBJ_387 /* BooleanFunctions.swift in Sources */,
 				OBJ_388 /* Curry.swift in Sources */,
+				1168901D21638B3D00F3A7A6 /* Store.swift in Sources */,
 				OBJ_389 /* Const.swift in Sources */,
 				OBJ_390 /* Coproduct.swift in Sources */,
 				1156839D216247290001749D /* Invariant.swift in Sources */,

--- a/Sources/Bow/Data/Day.swift
+++ b/Sources/Bow/Data/Day.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+public class ForDay {}
+public typealias DayOf<F, G, A> = Kind3<ForDay, F, G, A>
+
+public class Day<F, G, A> : DayOf<F, G, A> {
+    public static func fix(_ value : DayOf<F, G, A>) -> Day<F, G, A> {
+        return value as! Day<F, G, A>
+    }
+    
+    public static func pure<ApplF, ApplG>(_ applicativeF : ApplF, _ applicativeG : ApplG, _ a : A) -> Day<F, G, A> where ApplF : Applicative, ApplF.F == F, ApplG : Applicative, ApplG.F == G {
+        return DefaultDay(left: applicativeF.pure(unit),
+                          right: applicativeG.pure(unit),
+                          f: constant(a))
+    }
+    
+    public static func from<X, Y>(left : Kind<F, X>, right : Kind<G, Y>, f : @escaping (X, Y) -> A) -> Day<F, G, A> {
+        return DefaultDay(left: left, right: right, f: f)
+    }
+    
+    public func runDay<ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG) -> A where ComonF : Comonad, ComonF.F == F, ComonG : Comonad, ComonG.F == G {
+        return extract(comonadF, comonadG)
+    }
+    
+    public func extract<ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG) -> A where ComonF : Comonad, ComonF.F == F, ComonG : Comonad, ComonG.F == G {
+        fatalError("extract must be implemented in subclasses")
+    }
+    
+    public func map<B>(_ f : @escaping (A) -> B) -> Day<F, G, B> {
+        fatalError("map must be implemented in subclasses")
+    }
+    
+    public func ap<B, ApplF, ApplG>(_ applicativeF : ApplF, _ applicativeG : ApplG, _ f : DayOf<F, G, (A) -> B>) -> Day<F, G, B> where ApplF : Applicative, ApplF.F == F, ApplG : Applicative, ApplG.F == G {
+        fatalError("ap must be implemented in subclasses")
+    }
+    
+    public func coflatMap<B, ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG, _ f : @escaping (DayOf<F, G, A>) -> B) -> Day<F, G, B> where ComonF : Comonad, ComonF.F == F, ComonG : Comonad, ComonG.F == G {
+        fatalError("coflatMap must be implemented in subclasses")
+    }
+}
+
+fileprivate class DefaultDay<F, G, X, Y, A> : Day<F, G, A> {
+    private let left : Kind<F, X>
+    private let right : Kind<G, Y>
+    private let f : (X, Y) -> A
+    
+    init(left : Kind<F, X>, right : Kind<G, Y>, f : @escaping (X, Y) -> A) {
+        self.left = left
+        self.right = right
+        self.f = f
+    }
+    
+    func stepDay<R>(_ ff: @escaping (Kind<F, X>, Kind<G, Y>, @escaping (X, Y) -> A) -> R) -> R {
+        return ff(left, right, { a, b in self.f(a, b) })
+    }
+    
+    override public func extract<ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG) -> A where ComonF : Comonad, ComonF.F == F, ComonG : Comonad, ComonG.F == G {
+        return self.stepDay { left, right, get in
+            get(comonadF.extract(left), comonadG.extract(right))
+        }
+    }
+    
+    override public func map<B>(_ f : @escaping (A) -> B) -> Day<F, G, B> {
+        return self.stepDay { left, right, get in
+            DefaultDay<F, G, X, Y, B>(left: left, right: right) { x, y in
+                f(get(x, y))
+            }
+        }
+    }
+    
+    override public func ap<B, ApplF, ApplG>(_ applicativeF : ApplF, _ applicativeG : ApplG, _ f : DayOf<F, G, (A) -> B>) -> Day<F, G, B> where ApplF : Applicative, ApplF.F == F, ApplG : Applicative, ApplG.F == G {
+        return self.stepDay { left, right, get in
+            (Day<F, G, (A) -> B>.fix(f) as! DefaultDay<F, G, X, Y, (A) -> B>).stepDay { lf, rf, getf in
+                let l = applicativeF.tupled(left, lf)
+                let r = applicativeG.tupled(right, rf)
+                return DefaultDay<F, G, (X, X), (Y, Y), B>(left: l, right: r) { x, y in
+                    getf(x.1, y.1)(get(x.0, y.0))
+                }
+            }
+        }
+    }
+    
+    override public func coflatMap<B, ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG, _ f : @escaping (DayOf<F, G, A>) -> B) -> Day<F, G, B> where ComonF : Comonad, ComonF.F == F, ComonG : Comonad, ComonG.F == G {
+        return self.stepDay { left, right, get in
+            let l = comonadF.duplicate(left)
+            let r = comonadG.duplicate(right)
+            return DefaultDay<F, G, Kind<F, X>, Kind<G, Y>, B>(left: l, right: r) { x, y in
+                f(DefaultDay(left: x, right: y, f: get))
+            }
+        }
+    }
+}

--- a/Sources/Bow/Data/Moore.swift
+++ b/Sources/Bow/Data/Moore.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public class ForMoore {}
 public typealias MooreOf<E, V> = Kind2<ForMoore, E, V>
+public typealias MoorePartial<E> = Kind<ForMoore, E>
 
 public class Moore<E, V> : MooreOf<E, V> {
     public let view : V
@@ -28,5 +29,33 @@ public class Moore<E, V> : MooreOf<E, V> {
     
     func extract() -> V {
         return view
+    }
+}
+
+public extension Moore {
+    public static func functor() -> MooreFunctor<E> {
+        return MooreFunctor<E>()
+    }
+    
+    public static func comonad() -> MooreComonad<E> {
+        return MooreComonad<E>()
+    }
+}
+
+public class MooreFunctor<E> : Functor {
+    public typealias F = MoorePartial<E>
+    
+    public func map<A, B>(_ fa: MooreOf<E, A>, _ f: @escaping (A) -> B) -> MooreOf<E, B> {
+        return Moore<E, A>.fix(fa).map(f)
+    }
+}
+
+public class MooreComonad<E> : MooreFunctor<E>, Comonad {
+    public func coflatMap<A, B>(_ fa: Kind<Kind<ForMoore, E>, A>, _ f: @escaping (Kind<Kind<ForMoore, E>, A>) -> B) -> Kind<Kind<ForMoore, E>, B> {
+        return Moore<E, A>.fix(fa).coflatMap(f)
+    }
+    
+    public func extract<A>(_ fa: Kind<Kind<ForMoore, E>, A>) -> A {
+        return Moore<E, A>.fix(fa).extract()
     }
 }

--- a/Sources/Bow/Data/Moore.swift
+++ b/Sources/Bow/Data/Moore.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+public class ForMoore {}
+public typealias MooreOf<E, V> = Kind2<ForMoore, E, V>
+
+public class Moore<E, V> : MooreOf<E, V> {
+    public let view : V
+    public let handle : (E) -> Moore<E, V>
+    
+    public static func fix(_ value : MooreOf<E, V>) -> Moore<E, V> {
+        return value as! Moore<E, V>
+    }
+    
+    public init(view : V, handle : @escaping (E) -> Moore<E, V>) {
+        self.view = view
+        self.handle = handle
+    }
+    
+    func coflatMap<A>(_ f : @escaping (Moore<E, V>) -> A) -> Moore<E, A> {
+        return Moore<E, A>(view: f(self),
+                           handle: { update in self.handle(update).coflatMap(f) })
+    }
+    
+    func map<A>(_ f : @escaping (V) -> A) -> Moore<E, A> {
+        return Moore<E, A>(view: f(self.view),
+                           handle: { update in self.handle(update).map(f) })
+    }
+    
+    func extract() -> V {
+        return view
+    }
+}

--- a/Sources/Bow/Data/Store.swift
+++ b/Sources/Bow/Data/Store.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+public class ForStore {}
+public typealias StoreOf<S, V> = Kind2<ForStore, S, V>
+
+public class Store<S, V> : StoreOf<S, V> {
+    public let state : S
+    public let render : (S) -> V
+    
+    public static func fix(_ value : StoreOf<S, V>) -> Store<S, V> {
+        return value as! Store<S, V>
+    }
+    
+    public init(state : S, render : @escaping (S) -> V) {
+        self.state = state
+        self.render = render
+    }
+    
+    func map<A>(_ f : @escaping (V) -> A) -> Store<S, A> {
+        return Store<S, A>(state: self.state,
+                           render: { newState in f(self.render(newState)) })
+    }
+    
+    func coflatMap<A>(_ f : @escaping (Store<S, V>) -> A) -> Store<S, A> {
+        return Store<S, A>(state: self.state,
+                           render: { next in f(Store(state: next, render: self.render)) })
+    }
+    
+    func extract() -> V {
+        return render(state)
+    }
+    
+    func duplicate() -> Store<S, Store<S, V>> {
+        return coflatMap(id)
+    }
+    
+    func move(_ newState : S) -> Store<S, V> {
+        return duplicate().render(newState)
+    }
+}

--- a/Sources/Bow/Data/Store.swift
+++ b/Sources/Bow/Data/Store.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public class ForStore {}
 public typealias StoreOf<S, V> = Kind2<ForStore, S, V>
+public typealias StorePartial<S> = Kind<ForStore, S>
 
 public class Store<S, V> : StoreOf<S, V> {
     public let state : S
@@ -36,5 +37,33 @@ public class Store<S, V> : StoreOf<S, V> {
     
     func move(_ newState : S) -> Store<S, V> {
         return duplicate().render(newState)
+    }
+}
+
+public extension Store {
+    public static func functor() -> StoreFunctor<S> {
+        return StoreFunctor<S>()
+    }
+    
+    public static func comonad() -> StoreComonad<S> {
+        return StoreComonad<S>()
+    }
+}
+
+public class StoreFunctor<S> : Functor {
+    public typealias F = StorePartial<S>
+    
+    public func map<A, B>(_ fa: StoreOf<S, A>, _ f: @escaping (A) -> B) -> StoreOf<S, B> {
+        return Store<S, A>.fix(fa).map(f)
+    }
+}
+
+public class StoreComonad<S> : StoreFunctor<S>, Comonad {
+    public func coflatMap<A, B>(_ fa: StoreOf<S, A>, _ f: @escaping (StoreOf<S, A>) -> B) -> StoreOf<S, B> {
+        return Store<S, A>.fix(fa).coflatMap(f)
+    }
+    
+    public func extract<A>(_ fa: StoreOf<S, A>) -> A {
+        return Store<S, A>.fix(fa).extract()
     }
 }

--- a/Sources/Bow/Data/Sum.swift
+++ b/Sources/Bow/Data/Sum.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public class ForSum {}
 public typealias SumOf<F, G, V> = Kind3<ForSum, F, G, V>
+public typealias SumPartial<F, G> = Kind2<ForSum, F, G>
 
 public enum Side {
     case left
@@ -53,4 +54,52 @@ public class Sum<F, G, V> : SumOf<F, G, V> {
     public func change(side: Side) -> Sum<F, G, V> {
         return Sum(left: self.left, right: self.right, side: side)
     }
+}
+
+public extension Sum {
+    public static func functor<FuncF, FuncG>(_ functorF : FuncF, _ functorG : FuncG) -> SumFunctor<F, G, FuncF, FuncG> {
+        return SumFunctor(functorF, functorG)
+    }
+    
+    public static func comonad<ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG) -> SumComonad<F, G, ComonF, ComonG> {
+        return SumComonad(comonadF, comonadG)
+    }
+}
+
+public class SumFunctor<G, H, FuncG, FuncH> : Functor where FuncG : Functor, FuncG.F == G, FuncH : Functor, FuncH.F == H {
+    public typealias F = SumPartial<G, H>
+    
+    private let functorG : FuncG
+    private let functorH : FuncH
+    
+    public init(_ functorG : FuncG, _ functorH : FuncH) {
+        self.functorG = functorG
+        self.functorH = functorH
+    }
+    
+    public func map<A, B>(_ fa: SumOf<G, H, A>, _ f: @escaping (A) -> B) -> SumOf<G, H, B> {
+        return Sum<G, H, A>.fix(fa).map(functorG, functorH, f)
+    }
+}
+
+public class SumComonad<G, H, ComonG, ComonH> : SumFunctor<G, H, ComonG, ComonH>, Comonad where ComonG : Comonad, ComonG.F == G, ComonH : Comonad, ComonH.F == H {
+    
+    private let comonadG : ComonG
+    private let comonadH : ComonH
+    
+    override public init(_ comonadG : ComonG, _ comonadH : ComonH) {
+        self.comonadG = comonadG
+        self.comonadH = comonadH
+        super.init(comonadG, comonadH)
+    }
+    
+    public func coflatMap<A, B>(_ fa: SumOf<G, H, A>, _ f: @escaping (SumOf<G, H, A>) -> B) -> SumOf<G, H, B> {
+        return Sum<G, H, A>.fix(fa).coflatMap(comonadG, comonadH, f)
+    }
+    
+    public func extract<A>(_ fa: SumOf<G, H, A>) -> A {
+        return Sum<G, H, A>.fix(fa).extract(comonadG, comonadH)
+    }
+    
+    
 }

--- a/Sources/Bow/Data/Sum.swift
+++ b/Sources/Bow/Data/Sum.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+public class ForSum {}
+public typealias SumOf<F, G, V> = Kind3<ForSum, F, G, V>
+
+public enum Side {
+    case left
+    case right
+}
+
+public class Sum<F, G, V> : SumOf<F, G, V> {
+    public let left : Kind<F, V>
+    public let right : Kind<G, V>
+    public let side : Side
+    
+    public static func fix(_ value : SumOf<F, G, V>) -> Sum<F, G, V> {
+        return value as! Sum<F, G, V>
+    }
+    
+    public static func left(_ left : Kind<F, V>, _ right : Kind<G, V>) -> Sum<F, G, V> {
+        return Sum(left: left, right: right, side: .left)
+    }
+    
+    public static func right(_ left : Kind<F, V>, _ right : Kind<G, V>) -> Sum<F, G, V> {
+        return Sum(left: left, right: right, side: .right)
+    }
+
+    public init(left : Kind<F, V>, right : Kind<G, V>, side : Side = .left) {
+        self.left = left
+        self.right = right
+        self.side = side
+    }
+    
+    public func coflatMap<A, ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG, _ f : @escaping (Sum<F, G, V>) -> A) -> Sum<F, G, A> where ComonF : Comonad, ComonF.F == F, ComonG : Comonad, ComonG.F == G {
+        return Sum<F, G, A>(left: comonadF.coflatMap(self.left, { _ in f(Sum(left: self.left, right: self.right, side: .left)) }),
+                            right: comonadG.coflatMap(self.right, { _ in f(Sum(left: self.left, right: self.right, side: .right)) }),
+                            side: self.side)
+    }
+    
+    public func map<A, FuncF, FuncG>(_ functorF : FuncF, _ functorG : FuncG, _ f : @escaping (V) -> A) -> Sum<F, G, A> where FuncF : Functor, FuncF.F == F, FuncG : Functor, FuncG.F == G {
+        return Sum<F, G, A>(left: functorF.map(self.left, f),
+                            right: functorG.map(self.right, f),
+                            side: self.side)
+    }
+    
+    public func extract<ComonF, ComonG>(_ comonadF : ComonF, _ comonadG : ComonG) -> V where ComonF : Comonad, ComonF.F == F, ComonG : Comonad, ComonG.F == G {
+        switch self.side {
+        case .left: return comonadF.extract(self.left)
+        case .right: return comonadG.extract(self.right)
+        }
+    }
+    
+    public func change(side: Side) -> Sum<F, G, V> {
+        return Sum(left: self.left, right: self.right, side: side)
+    }
+}

--- a/Tests/BowTests/Data/DayTest.swift
+++ b/Tests/BowTests/Data/DayTest.swift
@@ -1,0 +1,46 @@
+import XCTest
+import Nimble
+@testable import Bow
+
+class DayTest : XCTestCase {
+    let cf = { (x : Int) in Day.from(left: Id(x), right: Id(0), f: +) }
+    
+    class DayEq : Eq {
+        typealias A = DayOf<ForId, ForId, Int>
+        
+        func eqv(_ a: DayOf<ForId, ForId, Int>, _ b: DayOf<ForId, ForId, Int>) -> Bool {
+            return Day<ForId, ForId, Int>.fix(a).extract(Id<Int>.comonad(), Id<Int>.comonad()) ==
+                Day<ForId, ForId, Int>.fix(b).extract(Id<Int>.comonad(), Id<Int>.comonad())
+        }
+    }
+    
+    let day = Day.from(left: Id(1), right: Id(1), f: { (left : Int, right : Int) in (left, right) })
+    let compareSides = { (left : Int, right : Int) -> String in
+        if left > right {
+            return "Left is greater"
+        } else if right > left {
+            return "Right is greater"
+        } else {
+            return "Both sides are equal"
+        }
+    }
+    
+    func testDayExtract() {
+        let result = day.extract(Id<Int>.comonad(), Id<Int>.comonad())
+        expect(result.0).to(equal(1))
+        expect(result.1).to(equal(1))
+    }
+    
+    func testDayCoflatMap() {
+        let transformed = day.coflatMap(Id<Int>.comonad(), Id<Int>.comonad()) { (x : DayOf<ForId, ForId, (Int, Int)>) -> String  in
+            let result = Day<ForId, ForId, (Int, Int)>.fix(x).extract(Id<Int>.comonad(), Id<Int>.comonad())
+            return self.compareSides(result.0, result.1)
+        }
+        expect(transformed.extract(Id<String>.comonad(), Id<String>.comonad())).to(equal("Both sides are equal"))
+    }
+    
+    func testDayMap() {
+        let mapped = day.map { x in self.compareSides(x.0, x.1) }
+        expect(mapped.extract(Id<String>.comonad(), Id<String>.comonad())).to(equal("Both sides are equal"))
+    }
+}

--- a/Tests/BowTests/Data/DayTest.swift
+++ b/Tests/BowTests/Data/DayTest.swift
@@ -14,6 +14,23 @@ class DayTest : XCTestCase {
         }
     }
     
+    class DayEqUnit : Eq {
+        typealias A = DayOf<ForId, ForId, ()>
+        
+        func eqv(_ a: DayOf<ForId, ForId, ()>, _ b: DayOf<ForId, ForId, ()>) -> Bool {
+            return Day<ForId, ForId, ()>.fix(a).extract(Id<Int>.comonad(), Id<()>.comonad()) ==
+                Day<ForId, ForId, ()>.fix(b).extract(Id<Int>.comonad(), Id<()>.comonad())
+        }
+    }
+    
+    func testFunctorLaws() {
+        FunctorLaws.check(functor: Day<ForId, ForId, Int>.functor(), generator: cf, eq: DayEq(), eqUnit: DayEqUnit())
+    }
+    
+    func testComonadLaws() {
+        ComonadLaws.check(comonad: Day<ForId, ForId, Int>.comonad(Id<Int>.comonad(), Id<Int>.comonad()), generator: cf, eq: DayEq())
+    }
+    
     let day = Day.from(left: Id(1), right: Id(1), f: { (left : Int, right : Int) in (left, right) })
     let compareSides = { (left : Int, right : Int) -> String in
         if left > right {

--- a/Tests/BowTests/Data/MooreTest.swift
+++ b/Tests/BowTests/Data/MooreTest.swift
@@ -1,0 +1,64 @@
+import XCTest
+import Nimble
+@testable import Bow
+
+class MooreTest : XCTestCase {
+    func handle(_ x : Int) -> Moore<Int, Int> {
+        return Moore(view: x, handle: handle)
+    }
+    
+    class MooreEq : Eq {
+        typealias A = MooreOf<Int, Int>
+        
+        func eqv(_ a: MooreOf<Int, Int>, _ b: MooreOf<Int, Int>) -> Bool {
+            return Moore<Int, Int>.fix(a).extract() == Moore<Int, Int>.fix(b).extract()
+        }
+    }
+    
+    func handleRoute(_ route : String) -> Moore<String, Id<String>> {
+        switch route {
+        case "About": return Moore(view: Id("About"), handle: handleRoute)
+        case "Home": return Moore(view: Id("Home"), handle: handleRoute)
+        default: return Moore(view: Id("???"), handle: handleRoute)
+        }
+    }
+    
+    var routerMoore : Moore<String, Id<String>>!
+    
+    override func setUp() {
+         routerMoore = Moore(view: Id("???"), handle: handleRoute)
+    }
+    
+    func testViewAfterHandle() {
+        let currentRoute = routerMoore.handle("About").extract().extract()
+        expect(currentRoute).to(equal("About"))
+    }
+    
+    func testViewAfterSeveralHandle() {
+        let currentRoute = routerMoore.handle("About").handle("Home").extract().extract()
+        expect(currentRoute).to(equal("Home"))
+    }
+    
+    func testViewAfterCoflatMap() {
+        let currentRoute = routerMoore!.coflatMap { (view) -> Int in
+            switch view.extract().extract() {
+            case "About": return 1
+            case "Home": return 2
+            default: return 0
+            }
+        }.extract()
+        
+        expect(currentRoute).to(equal(0))
+    }
+    
+    func testViewAfterMap() {
+        let currentRoute = routerMoore.map { (view : Id<String>) -> Int in
+            switch view.extract() {
+            case "About": return 1
+            case "Home": return 2
+            default: return 0
+            }
+        }.extract()
+        expect(currentRoute).to(equal(0))
+    }
+}

--- a/Tests/BowTests/Data/MooreTest.swift
+++ b/Tests/BowTests/Data/MooreTest.swift
@@ -15,6 +15,22 @@ class MooreTest : XCTestCase {
         }
     }
     
+    class MooreEqUnit : Eq {
+        typealias A = MooreOf<Int, ()>
+        
+        func eqv(_ a: MooreOf<Int, ()>, _ b: MooreOf<Int, ()>) -> Bool {
+            return Moore<Int, ()>.fix(a).extract() == Moore<Int, ()>.fix(b).extract()
+        }
+    }
+    
+    func testFunctorLaws() {
+        FunctorLaws.check(functor: Moore<Int, Int>.functor(), generator: handle, eq: MooreEq(), eqUnit: MooreEqUnit())
+    }
+    
+    func testComonadLaws() {
+        ComonadLaws.check(comonad: Moore<Int, Int>.comonad(), generator: handle, eq: MooreEq())
+    }
+    
     func handleRoute(_ route : String) -> Moore<String, Id<String>> {
         switch route {
         case "About": return Moore(view: Id("About"), handle: handleRoute)

--- a/Tests/BowTests/Data/StoreTest.swift
+++ b/Tests/BowTests/Data/StoreTest.swift
@@ -13,6 +13,22 @@ class StoreTest : XCTestCase {
         }
     }
     
+    class StoreEqUnit : Eq {
+        typealias A = StoreOf<Int, ()>
+        
+        func eqv(_ a: StoreOf<Int, ()>, _ b: StoreOf<Int, ()>) -> Bool {
+            return Store<Int, ()>.fix(a).extract() == Store<Int, ()>.fix(b).extract()
+        }
+    }
+    
+    func testFunctorLaws() {
+        FunctorLaws.check(functor: Store<Int, Int>.functor(), generator: intStore, eq: StoreEq(), eqUnit: StoreEqUnit())
+    }
+    
+    func testComonadLaws() {
+        ComonadLaws.check(comonad: Store<Int, Int>.comonad(), generator: intStore, eq: StoreEq())
+    }
+    
     let greetingStore = { (name : String) in Store(state: name, render: { name in "Hi \(name)!"}) }
     
     func testExtractRendersCurrentState() {

--- a/Tests/BowTests/Data/StoreTest.swift
+++ b/Tests/BowTests/Data/StoreTest.swift
@@ -1,0 +1,38 @@
+import XCTest
+import Nimble
+@testable import Bow
+
+class StoreTest : XCTestCase {
+    let intStore = { (x : Int) in Store(state: x, render: id) }
+    
+    class StoreEq : Eq {
+        typealias A = StoreOf<Int, Int>
+        
+        func eqv(_ a: StoreOf<Int, Int>, _ b: StoreOf<Int, Int>) -> Bool {
+            return Store<Int, Int>.fix(a).extract() == Store<Int, Int>.fix(b).extract()
+        }
+    }
+    
+    let greetingStore = { (name : String) in Store(state: name, render: { name in "Hi \(name)!"}) }
+    
+    func testExtractRendersCurrentState() {
+        let result = greetingStore("Bow")
+        expect(result.extract()).to(equal("Hi Bow!"))
+    }
+    
+    func testCoflatMapCreatesNewStore() {
+        let result = greetingStore("Bow").coflatMap { (store) -> String in
+            if store.state == "Bow" {
+                return "This is my master"
+            } else {
+                return "This is not my master"
+            }
+        }
+        expect(result.extract()).to(equal("This is my master"))
+    }
+    
+    func testMapModifiesRenderResult() {
+        let result = greetingStore("Bow").map { str in str.uppercased() }
+        expect(result.extract()).to(equal("HI BOW!"))
+    }
+}

--- a/Tests/BowTests/Data/SumTest.swift
+++ b/Tests/BowTests/Data/SumTest.swift
@@ -1,0 +1,41 @@
+import XCTest
+import Nimble
+@testable import Bow
+
+class SumTest : XCTestCase {
+    
+    let cf = { (x : Int) in Sum.left(Id(x), Id(x)) }
+    
+    class SumEq : Eq {
+        typealias A = SumOf<ForId, ForId, Int>
+        
+        func eqv(_ a: SumOf<ForId, ForId, Int>, _ b: SumOf<ForId, ForId, Int>) -> Bool {
+            return Sum<ForId, ForId, Int>.fix(a).extract(Id<Int>.comonad(), Id<Int>.comonad()) ==
+                Sum<ForId, ForId, Int>.fix(b).extract(Id<Int>.comonad(), Id<Int>.comonad())
+        }
+    }
+    
+    let abSum = Sum.left(Id("A"), Id("B"))
+    
+    func testSumExtractReturnsViewOfCurrentSide() {
+        expect(self.abSum.extract(Id<String>.comonad(), Id<String>.comonad())).to(equal("A"))
+        expect(self.abSum.change(side: .right).extract(Id<String>.comonad(), Id<String>.comonad())).to(equal("B"))
+    }
+    
+    func testCoflatMapTransformsViewType() {
+        let firstCharacter = { (x : String) in x.first! }
+        let result = abSum.coflatMap(Id<String>.comonad(), Id<String>.comonad()) { (sum) -> Character in
+            switch sum.side {
+            case .left: return firstCharacter(sum.left.fix().extract())
+            case .right: return firstCharacter(sum.right.fix().extract())
+            }
+        }
+        expect(result.extract(Id<Character>.comonad(), Id<Character>.comonad())).to(equal(Character("A")))
+    }
+    
+    func testMapTransformsViewType() {
+        let firstCharacter = { (x : String) in x.first! }
+        let result = abSum.map(Id<String>.functor(), Id<String>.functor(), firstCharacter)
+        expect(result.extract(Id<Character>.comonad(), Id<Character>.comonad())).to(equal(Character("A")))
+    }
+}

--- a/Tests/BowTests/Data/SumTest.swift
+++ b/Tests/BowTests/Data/SumTest.swift
@@ -15,6 +15,23 @@ class SumTest : XCTestCase {
         }
     }
     
+    class SumEqUnit : Eq {
+        typealias A = SumOf<ForId, ForId, ()>
+        
+        func eqv(_ a: SumOf<ForId, ForId, ()>, _ b: SumOf<ForId, ForId, ()>) -> Bool {
+            return Sum<ForId, ForId, ()>.fix(a).extract(Id<()>.comonad(), Id<()>.comonad()) ==
+                Sum<ForId, ForId, ()>.fix(b).extract(Id<()>.comonad(), Id<()>.comonad())
+        }
+    }
+    
+    func testFunctorLaws() {
+        FunctorLaws.check(functor: Sum<ForId, ForId, Int>.functor(Id<Int>.functor(), Id<Int>.functor()), generator: cf, eq: SumEq(), eqUnit: SumEqUnit())
+    }
+    
+    func testComonadLaws() {
+        ComonadLaws.check(comonad: Sum<ForId, ForId, Int>.comonad(Id<Int>.comonad(), Id<Int>.comonad()), generator: cf, eq: SumEq())
+    }
+    
     let abSum = Sum.left(Id("A"), Id("B"))
     
     func testSumExtractReturnsViewOfCurrentSide() {


### PR DESCRIPTION
This PR adds several data types described in the paper [Declarative UIs are the Future - and the Future is Comonadic!](https://functorial.com/the-future-is-comonadic/main.pdf) and implemented as in [this PR in Arrow](https://github.com/arrow-kt/arrow/pull/1020). The included data types are:

- Store
- Moore
- Sum
- Day

The only missing things with respect to the Arrow version are the `lazy` versions of methods in `Day`, and the applicative instances. I had several problems with types and generics and couldn't implement them in a safe way. I'd probably need to revisit this in the future.